### PR TITLE
Feature/completion item/resolve

### DIFF
--- a/pyls/hookspecs.py
+++ b/pyls/hookspecs.py
@@ -28,6 +28,11 @@ def pyls_completions(config, workspace, document, position):
 
 
 @hookspec
+def pyls_completion_item_resolve(config, workspace, completion_item):
+    pass
+
+
+@hookspec
 def pyls_definitions(config, workspace, document, position):
     pass
 

--- a/pyls/hookspecs.py
+++ b/pyls/hookspecs.py
@@ -27,7 +27,7 @@ def pyls_completions(config, workspace, document, position):
     pass
 
 
-@hookspec
+@hookspec(firstresult=True)
 def pyls_completion_item_resolve(config, workspace, completion_item):
     pass
 

--- a/pyls/plugins/jedi_completion.py
+++ b/pyls/plugins/jedi_completion.py
@@ -56,6 +56,8 @@ _LAST_COMPLETIONS = {}
 @hookimpl
 def pyls_completions(config, document, position):
     """Get formatted completions for current code position"""
+    # pylint: disable=too-many-locals
+    # pylint: disable=global-statement
     global _LAST_COMPLETIONS
 
     settings = config.plugin_settings('jedi_completion', document_path=document.path)
@@ -100,7 +102,7 @@ def pyls_completions(config, document, position):
 
 
 @hookimpl
-def pyls_completion_item_resolve(config, completion_item):
+def pyls_completion_item_resolve(completion_item):
     """Resolve formatted completion for given non-resolved completion"""
     completion, data = _LAST_COMPLETIONS.get(completion_item['label'])
     return _resolve_completion(completion, data)

--- a/pyls/plugins/rope_completion.py
+++ b/pyls/plugins/rope_completion.py
@@ -10,6 +10,7 @@ log = logging.getLogger(__name__)
 # most recently retrieved completion items, used for resolution
 _LAST_COMPLETIONS = {}
 
+
 @hookimpl
 def pyls_settings():
     # Default rope_completion to disabled
@@ -28,6 +29,8 @@ def _resolve_completion(completion, data):
 
 @hookimpl
 def pyls_completions(config, workspace, document, position):
+    # pylint: disable=too-many-locals
+    # pylint: disable=global-statement
     global _LAST_COMPLETIONS
 
     settings = config.plugin_settings('rope_completion', document_path=document.path)
@@ -77,7 +80,7 @@ def pyls_completions(config, workspace, document, position):
 
 
 @hookimpl
-def pyls_completion_item_resolve(config, completion_item):
+def pyls_completion_item_resolve(completion_item):
     """Resolve formatted completion for given non-resolved completion"""
     completion, data = _LAST_COMPLETIONS.get(completion_item['label'])
     return _resolve_completion(completion, data)

--- a/pyls/python_ls.py
+++ b/pyls/python_ls.py
@@ -162,8 +162,8 @@ class PythonLanguageServer(MethodDispatcher):
                 'resolveProvider': False,  # We may need to make this configurable
             },
             'completionProvider': {
-                'resolveProvider': False,  # We know everything ahead of time
-                'triggerCharacters': ['.']
+                'resolveProvider': True,  # We could know everything ahead of time, but this takes time to transfer
+                'triggerCharacters': ['.'],
             },
             'documentFormattingProvider': True,
             'documentHighlightProvider': True,
@@ -243,6 +243,9 @@ class PythonLanguageServer(MethodDispatcher):
             'items': flatten(completions)
         }
 
+    def completion_item_resolve(self, completion_item):
+        return self._hook('pyls_completion_item_resolve', completion_item=completion_item)
+
     def definitions(self, doc_uri, position):
         return flatten(self._hook('pyls_definitions', doc_uri, position=position))
 
@@ -288,6 +291,9 @@ class PythonLanguageServer(MethodDispatcher):
 
     def folding(self, doc_uri):
         return flatten(self._hook('pyls_folding_range', doc_uri))
+
+    def m_completion_item__resolve(self, **completionItem):
+        return self.completion_item_resolve(completionItem)
 
     def m_text_document__did_close(self, textDocument=None, **_kwargs):
         workspace = self._match_uri_to_workspace(textDocument['uri'])

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -81,7 +81,6 @@ def test_jedi_completion_item_resolve(config, workspace):
     assert 'detail' not in documented_hello_item
 
     resolved_documented_hello = pyls_jedi_completion_item_resolve(
-        config,
         completion_item=documented_hello_item
     )
     assert 'Sends a polite greeting' in resolved_documented_hello['documentation']
@@ -359,7 +358,7 @@ def test_jedi_completion_environment(workspace):
     completions = pyls_jedi_completions(doc._config, doc, com_position)
     assert completions[0]['label'] == 'loghub'
 
-    resolved = pyls_jedi_completion_item_resolve(doc._config, completions[0])
+    resolved = pyls_jedi_completion_item_resolve(completions[0])
     assert 'changelog generator' in resolved['documentation'].lower()
 
 

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -359,7 +359,7 @@ def test_jedi_completion_environment(workspace):
     completions = pyls_jedi_completions(doc._config, doc, com_position)
     assert completions[0]['label'] == 'loghub'
 
-    resolved = pyls_jedi_completion_item_resolve(completions[0]['documentation'])
+    resolved = pyls_jedi_completion_item_resolve(doc._config, completions[0])
     assert 'changelog generator' in resolved['documentation'].lower()
 
 

--- a/vscode-client/package.json
+++ b/vscode-client/package.json
@@ -70,6 +70,11 @@
                     "default": false,
                     "description": "Enable fuzzy when requesting autocomplete."
                 },
+                "pyls.plugins.jedi_completion.eager": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Resolve documentation and detail eagerly."
+                },
                 "pyls.plugins.jedi_definition.enabled": {
                     "type": "boolean",
                     "default": true,
@@ -273,6 +278,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Enable or disable the plugin."
+                },
+                "pyls.plugins.rope_completion.eager": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Resolve documentation and detail eagerly."
                 },
                 "pyls.plugins.yapf.enabled": {
                     "type": "boolean",


### PR DESCRIPTION
Supersedes https://github.com/palantir/python-language-server/pull/905.

- implemented new hook for resolve
- implemented resolve in jedi_completion and rope_completion
- added `eager` option to rope_completion and jedi_completion allow users using clients which cannot yet handle `completionItem/resolve` to restore to eager resolution (inside of `textDocument/completions`)
- added test for resolve and documentation in Jedi
- tested with development version of [JupyterLab-LSP](https://github.com/krassowski/jupyterlab-lsp) client; the client implementation was tested against reference JavaScript/TypeScript server and against the R-languageserver