### PR TITLE
Unpin numpy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
         'yapf': ['yapf'],
         'test': ['versioneer',
                  'pylint>=2.5.0' if sys.version_info.major >= 3 else 'pylint',
-                 'pytest', 'mock', 'pytest-cov', 'coverage', 'numpy<1.20', 'pandas',
+                 'pytest', 'mock', 'pytest-cov', 'coverage', 'numpy', 'pandas',
                  'matplotlib', 'pyqt5;python_version>="3"', 'flaky'],
     },
 

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -216,14 +216,14 @@ def test_completion_with_class_objects(config, workspace):
 
 
 def test_snippet_parsing(config, workspace):
-    doc = 'import numpy as np\nnp.logical_and'
-    completion_position = {'line': 1, 'character': 14}
+    doc = 'divmod'
+    completion_position = {'line': 0, 'character': 6}
     doc = Document(DOC_URI, workspace, doc)
     config.capabilities['textDocument'] = {
         'completion': {'completionItem': {'snippetSupport': True}}}
     config.update({'plugins': {'jedi_completion': {'include_params': True}}})
     completions = pyls_jedi_completions(config, doc, completion_position)
-    out = 'logical_and(${1:x1}, ${2:x2})$0'
+    out = 'divmod(${1:a}, ${2:b})$0'
     assert completions[0]['insertText'] == out
 
 

--- a/test/plugins/test_hover.py
+++ b/test/plugins/test_hover.py
@@ -46,9 +46,13 @@ def test_numpy_hover(workspace):
     contents = 'NumPy\n=====\n\nProvides\n'
     assert contents in pyls_hover(doc, numpy_hov_position_3)['contents'][0]
 
-    contents = 'Trigonometric sine, element-wise.\n\n'
-    assert contents in pyls_hover(
-        doc, numpy_sin_hov_position)['contents'][0]
+    # https://github.com/davidhalter/jedi/issues/1746
+    import numpy as np
+
+    if np.lib.NumpyVersion(np.__version__) < '1.20.0':
+        contents = 'Trigonometric sine, element-wise.\n\n'
+        assert contents in pyls_hover(
+            doc, numpy_sin_hov_position)['contents'][0]
 
 
 def test_hover(workspace):


### PR DESCRIPTION
* There is no need for `test_snippet_parsing` to use NumPy
* Work around https://github.com/davidhalter/jedi/issues/1746 (https://github.com/palantir/python-language-server/issues/906) by not testing the hover for `np.sin`