### PR TITLE
PR: Use python-lsp-jsonrpc instead of python-jsonrpc-server

### DIFF
--- a/pylsp/python_lsp.py
+++ b/pylsp/python_lsp.py
@@ -7,9 +7,9 @@ import os
 import socketserver
 import threading
 
-from pyls_jsonrpc.dispatchers import MethodDispatcher
-from pyls_jsonrpc.endpoint import Endpoint
-from pyls_jsonrpc.streams import JsonRpcStreamReader, JsonRpcStreamWriter
+from pylsp_jsonrpc.dispatchers import MethodDispatcher
+from pylsp_jsonrpc.endpoint import Endpoint
+from pylsp_jsonrpc.streams import JsonRpcStreamReader, JsonRpcStreamWriter
 
 from . import lsp, _utils, uris
 from .config import config

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ README = open('README.md', 'r').read()
 
 install_requires = [
     'jedi>=0.17.2,<0.19.0',
-    'python-jsonrpc-server>=0.4.0',
+    'python-lsp-jsonrpc>=1.0.0',
     'pluggy',
     'ujson>=3.0.0'
 ]

--- a/test/test_language_server.py
+++ b/test/test_language_server.py
@@ -7,7 +7,7 @@ import multiprocessing
 import sys
 from threading import Thread
 
-from pyls_jsonrpc.exceptions import JsonRpcMethodNotFound
+from pylsp_jsonrpc.exceptions import JsonRpcMethodNotFound
 import pytest
 
 from pylsp.python_lsp import start_io_lang_server, PythonLSPServer


### PR DESCRIPTION
This PR aligns both forks of the organization and detaches python-lsp-server from python-language-server effectively.