### PR TITLE
PR: Small fix in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The default configuration source is pycodestyle. Change the `pylsp.configuration
 Overall configuration is computed first from user configuration (in home directory), overridden by configuration passed in by the language client, and then overriden by configuration discovered in the workspace.
 
 To enable pydocstyle for linting docstrings add the following setting in your LSP configuration:
-`\` "pylsp.plugins.pydocstyle.enabled": true \``
+`"pylsp.plugins.pydocstyle.enabled": true`
 
 ## Language Server Features
 


### PR DESCRIPTION
I have fixed the README for `pylsp`.

This is partly because the original palantir/python-language-server README itself is wrong. The code block is for Markdown even though it is reStructuredText. https://github.com/palantir/python-language-server/blame/develop/README.rst#L74-L76