### PR TITLE
Fix Jedi type map (use types offered by modern Jedi)

### DIFF
--- a/pylsp/plugins/jedi_completion.py
+++ b/pylsp/plugins/jedi_completion.py
@@ -10,39 +10,21 @@ from pylsp import _utils, hookimpl, lsp
 
 log = logging.getLogger(__name__)
 
-# Map to the VSCode type
+# Map to the LSP type
+# > Valid values for type are ``module``, `` class ``, ``instance``, ``function``,
+# > ``param``, ``path``, ``keyword``, ``property`` and ``statement``.
+# see: https://jedi.readthedocs.io/en/latest/docs/api-classes.html#jedi.api.classes.BaseName.type
 _TYPE_MAP = {
-    'none': lsp.CompletionItemKind.Value,
-    'type': lsp.CompletionItemKind.Class,
-    'tuple': lsp.CompletionItemKind.Class,
-    'dict': lsp.CompletionItemKind.Class,
-    'dictionary': lsp.CompletionItemKind.Class,
-    'function': lsp.CompletionItemKind.Function,
-    'lambda': lsp.CompletionItemKind.Function,
-    'generator': lsp.CompletionItemKind.Function,
+    'module': lsp.CompletionItemKind.Module,
+    'namespace': lsp.CompletionItemKind.Module,    # to be added in Jedi 0.18+
     'class': lsp.CompletionItemKind.Class,
     'instance': lsp.CompletionItemKind.Reference,
-    'method': lsp.CompletionItemKind.Method,
-    'builtin': lsp.CompletionItemKind.Class,
-    'builtinfunction': lsp.CompletionItemKind.Function,
-    'module': lsp.CompletionItemKind.Module,
-    'file': lsp.CompletionItemKind.File,
-    'path': lsp.CompletionItemKind.Text,
-    'xrange': lsp.CompletionItemKind.Class,
-    'slice': lsp.CompletionItemKind.Class,
-    'traceback': lsp.CompletionItemKind.Class,
-    'frame': lsp.CompletionItemKind.Class,
-    'buffer': lsp.CompletionItemKind.Class,
-    'dictproxy': lsp.CompletionItemKind.Class,
-    'funcdef': lsp.CompletionItemKind.Function,
-    'property': lsp.CompletionItemKind.Property,
-    'import': lsp.CompletionItemKind.Module,
-    'keyword': lsp.CompletionItemKind.Keyword,
-    'constant': lsp.CompletionItemKind.Variable,
-    'variable': lsp.CompletionItemKind.Variable,
-    'value': lsp.CompletionItemKind.Value,
+    'function': lsp.CompletionItemKind.Function,
     'param': lsp.CompletionItemKind.Variable,
-    'statement': lsp.CompletionItemKind.Keyword,
+    'path': lsp.CompletionItemKind.File,
+    'keyword': lsp.CompletionItemKind.Keyword,
+    'property': lsp.CompletionItemKind.Property,    # added in Jedi 0.18
+    'statement': lsp.CompletionItemKind.Variable
 }
 
 # Types of parso nodes for which snippet is not included in the completion

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -13,6 +13,7 @@ from pylsp import uris, lsp
 from pylsp.workspace import Document
 from pylsp.plugins.jedi_completion import pylsp_completions as pylsp_jedi_completions
 from pylsp.plugins.rope_completion import pylsp_completions as pylsp_rope_completions
+from pylsp._utils import JEDI_VERSION
 
 
 PY2 = sys.version[0] == '2'
@@ -114,11 +115,8 @@ TYPE_CASES: Dict[str, TypeCase] = {
 
 @pytest.mark.parametrize('case', list(TYPE_CASES.values()), ids=list(TYPE_CASES.keys()))
 def test_jedi_completion_type(case, config, workspace):
-    # pylint: disable=C0415
-    import jedi
-
     # property support was introduced in 0.18
-    if case.expected == lsp.CompletionItemKind.Property and jedi.__version__.startswith('0.17'):
+    if case.expected == lsp.CompletionItemKind.Property and JEDI_VERSION.startswith('0.17'):
         return
 
     doc = Document(DOC_URI, workspace, case.document)


### PR DESCRIPTION
The type map used by Jedi completion is severely outdated (includes types that are never returned by Jedi, and is missing types which are). This PR updates the types list (including future-proof namespace which is going to be introduced in next release) and adds a test to verify that these types actually are returned by Jedi for objects of such types (and properly mapped to LSP types).