### PR TITLE
PR: Address pylint's "consider-using-with" warnings

### DIFF
--- a/pylsp/plugins/flake8_lint.py
+++ b/pylsp/plugins/flake8_lint.py
@@ -5,6 +5,7 @@
 import logging
 import os.path
 import re
+from contextlib import ExitStack
 from subprocess import Popen, PIPE
 from pylsp import hookimpl, lsp
 
@@ -65,16 +66,20 @@ def run_flake8(flake8_executable, args, document):
         )
 
     log.debug("Calling %s with args: '%s'", flake8_executable, args)
-    try:
-        cmd = [flake8_executable]
-        cmd.extend(args)
-        p = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
-    except IOError:
-        log.debug("Can't execute %s. Trying with 'python -m flake8'", flake8_executable)
-        cmd = ['python', '-m', 'flake8']
-        cmd.extend(args)
-        p = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
-    (stdout, stderr) = p.communicate(document.source.encode())
+    with ExitStack() as stack:
+        try:
+            cmd = [flake8_executable]
+            cmd.extend(args)
+            p = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)  # pylint: disable=consider-using-with
+            stack.enter_context(p)
+        except IOError:
+            log.debug("Can't execute %s. Trying with 'python -m flake8'", flake8_executable)
+            cmd = ['python', '-m', 'flake8']
+            cmd.extend(args)
+            p = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)  # pylint: disable=consider-using-with
+            stack.enter_context(p)
+        # exit stack ensures that even if an exception happens, the process `p` will be properly terminated
+        (stdout, stderr) = p.communicate(document.source.encode())
     if stderr:
         log.error("Error while running flake8 '%s'", stderr.decode())
     return stdout.decode()

--- a/pylsp/plugins/pylint_lint.py
+++ b/pylsp/plugins/pylint_lint.py
@@ -7,7 +7,6 @@ import collections
 import logging
 import sys
 import re
-from contextlib import ExitStack
 from subprocess import Popen, PIPE
 
 from pylint.epylint import py_run
@@ -233,21 +232,18 @@ def _run_pylint_stdio(pylint_executable, document, flags):
     :rtype: string
     """
     log.debug("Calling %s with args: '%s'", pylint_executable, flags)
-    with ExitStack() as stack:
-        try:
-            cmd = [pylint_executable]
-            cmd.extend(flags)
-            cmd.extend(['--from-stdin', document.path])
-            p = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)  # pylint: disable=consider-using-with
-            stack.enter_context(p)
-        except IOError:
-            log.debug("Can't execute %s. Trying with 'python -m pylint'", pylint_executable)
-            cmd = ['python', '-m', 'pylint']
-            cmd.extend(flags)
-            cmd.extend(['--from-stdin', document.path])
-            p = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)  # pylint: disable=consider-using-with
-            stack.enter_context(p)
-        (stdout, stderr) = p.communicate(document.source.encode())
+    try:
+        cmd = [pylint_executable]
+        cmd.extend(flags)
+        cmd.extend(['--from-stdin', document.path])
+        p = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)  # pylint: disable=consider-using-with
+    except IOError:
+        log.debug("Can't execute %s. Trying with 'python -m pylint'", pylint_executable)
+        cmd = ['python', '-m', 'pylint']
+        cmd.extend(flags)
+        cmd.extend(['--from-stdin', document.path])
+        p = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)  # pylint: disable=consider-using-with
+    (stdout, stderr) = p.communicate(document.source.encode())
     if stderr:
         log.error("Error while running pylint '%s'", stderr.decode())
     return stdout.decode()

--- a/test/plugins/test_flake8_lint.py
+++ b/test/plugins/test_flake8_lint.py
@@ -21,10 +21,9 @@ def using_const():
 
 
 def temp_document(doc_text, workspace):
-    temp_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
-    name = temp_file.name
-    temp_file.write(doc_text)
-    temp_file.close()
+    with tempfile.NamedTemporaryFile(mode='w', delete=False) as temp_file:
+        name = temp_file.name
+        temp_file.write(doc_text)
     doc = Document(uris.from_fs_path(name), workspace)
 
     return name, doc

--- a/test/plugins/test_pylint_lint.py
+++ b/test/plugins/test_pylint_lint.py
@@ -28,10 +28,9 @@ DOC_SYNTAX_ERR = """def hello()
 @contextlib.contextmanager
 def temp_document(doc_text, workspace):
     try:
-        temp_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
-        name = temp_file.name
-        temp_file.write(doc_text)
-        temp_file.close()
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as temp_file:
+            name = temp_file.name
+            temp_file.write(doc_text)
         yield Document(uris.from_fs_path(name), workspace)
     finally:
         os.remove(name)


### PR DESCRIPTION
Fixes #19 by adding context managers in all places flagged by `consider-using-with`. [ExitStack](https://docs.python.org/3/library/contextlib.html#contextlib.ExitStack) was added in places where the simple `with` statement cannot be used.