### PR TITLE
Feature/completion item/resolve

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -11,6 +11,7 @@ This server can be configured using `workspace/didChangeConfiguration` method. E
 | `pylsp.plugins.jedi_completion.include_params` | `boolean` | Auto-completes methods and classes with tabstops for each parameter. | `true` |
 | `pylsp.plugins.jedi_completion.include_class_objects` | `boolean` | Adds class objects as a separate completion item. | `true` |
 | `pylsp.plugins.jedi_completion.fuzzy` | `boolean` | Enable fuzzy when requesting autocomplete. | `false` |
+| `pylsp.plugins.jedi_completion.eager` | `boolean` | Resolve documentation and detail eagerly. | `false` |
 | `pylsp.plugins.jedi_definition.enabled` | `boolean` | Enable or disable the plugin. | `true` |
 | `pylsp.plugins.jedi_definition.follow_imports` | `boolean` | The goto call will follow imports. | `true` |
 | `pylsp.plugins.jedi_definition.follow_builtin_imports` | `boolean` | If follow_imports is True will decide if it follow builtin imports. | `true` |

--- a/pylsp/config/schema.json
+++ b/pylsp/config/schema.json
@@ -49,6 +49,11 @@
       "default": false,
       "description": "Enable fuzzy when requesting autocomplete."
     },
+    "pylsp.plugins.jedi_completion.eager": {
+      "type": "boolean",
+      "default": false,
+      "description": "Resolve documentation and detail eagerly."
+    },
     "pylsp.plugins.jedi_definition.enabled": {
       "type": "boolean",
       "default": true,

--- a/pylsp/hookspecs.py
+++ b/pylsp/hookspecs.py
@@ -30,7 +30,7 @@ def pylsp_completions(config, workspace, document, position):
 
 
 @hookspec(firstresult=True)
-def pylsp_completion_item_resolve(config, workspace, completion_item):
+def pylsp_completion_item_resolve(config, workspace, document, completion_item):
     pass
 
 

--- a/pylsp/hookspecs.py
+++ b/pylsp/hookspecs.py
@@ -29,7 +29,7 @@ def pylsp_completions(config, workspace, document, position):
     pass
 
 
-@hookspec
+@hookspec(firstresult=True)
 def pylsp_completion_item_resolve(config, workspace, completion_item):
      pass
 

--- a/pylsp/hookspecs.py
+++ b/pylsp/hookspecs.py
@@ -30,6 +30,11 @@ def pylsp_completions(config, workspace, document, position):
 
 
 @hookspec
+def pylsp_completion_item_resolve(config, workspace, completion_item):
+     pass
+
+
+@hookspec
 def pylsp_definitions(config, workspace, document, position):
     pass
 

--- a/pylsp/hookspecs.py
+++ b/pylsp/hookspecs.py
@@ -31,7 +31,7 @@ def pylsp_completions(config, workspace, document, position):
 
 @hookspec(firstresult=True)
 def pylsp_completion_item_resolve(config, workspace, completion_item):
-     pass
+    pass
 
 
 @hookspec

--- a/pylsp/plugins/jedi_completion.py
+++ b/pylsp/plugins/jedi_completion.py
@@ -68,6 +68,7 @@ def pylsp_completions(config, document, position):
         for c in completions
     ]
 
+    # TODO split up once other improvements are merged
     if include_class_objects:
         for c in completions:
             if c.type == 'class':

--- a/pylsp/plugins/jedi_completion.py
+++ b/pylsp/plugins/jedi_completion.py
@@ -33,11 +33,17 @@ _IMPORTS = ('import_name', 'import_from')
 # Types of parso node for errors
 _ERRORS = ('error_node', )
 
+# most recently retrieved completion items, used for resolution
+_LAST_COMPLETIONS = {}
+
 
 @hookimpl
 def pylsp_completions(config, document, position):
     """Get formatted completions for current code position"""
+    global _LAST_COMPLETIONS
+
     settings = config.plugin_settings('jedi_completion', document_path=document.path)
+    resolve_eagerly = settings.get('eager', False)
     code_position = _utils.position_to_jedi_linecolumn(document, position)
 
     code_position["fuzzy"] = settings.get("fuzzy", False)
@@ -63,12 +69,25 @@ def pylsp_completions(config, document, position):
     if include_class_objects:
         for c in completions:
             if c.type == 'class':
-                completion_dict = _format_completion(c, False)
+                completion_dict = _format_completion(c, False, resolve=resolve_eagerly)
                 completion_dict['kind'] = lsp.CompletionItemKind.TypeParameter
                 completion_dict['label'] += ' object'
                 ready_completions.append(completion_dict)
 
+    _LAST_COMPLETIONS = {
+        # label is the only required property; here it is assumed to be unique
+        completion['label']: (completion, data)
+        for completion, data in zip(ready_completions, completions)
+    }
+
     return ready_completions or None
+
+
+@hookimpl
+def pylsp_completion_item_resolve(config, completion_item):
+    """Resolve formatted completion for given non-resolved completion"""
+    completion, data = _LAST_COMPLETIONS.get(completion_item['label'])
+    return _resolve_completion(completion, data)
 
 
 def is_exception_class(name):
@@ -121,15 +140,22 @@ def use_snippets(document, position):
             not (expr_type in _ERRORS and 'import' in code))
 
 
-def _format_completion(d, include_params=True):
+def _resolve_completion(completion, d):
+    completion['detail'] = _detail(d)
+    completion['documentation'] = _utils.format_docstring(d.docstring())
+    return completion
+
+
+def _format_completion(d, include_params=True, resolve=False):
     completion = {
         'label': _label(d),
         'kind': _TYPE_MAP.get(d.type),
-        'detail': _detail(d),
-        'documentation': _utils.format_docstring(d.docstring()),
         'sortText': _sort_text(d),
         'insertText': d.name
     }
+
+    if resolve:
+        completion = _resolve_completion(completion, d)
 
     if d.type == 'path':
         path = osp.normpath(d.name)

--- a/pylsp/plugins/jedi_completion.py
+++ b/pylsp/plugins/jedi_completion.py
@@ -40,6 +40,8 @@ _LAST_COMPLETIONS = {}
 @hookimpl
 def pylsp_completions(config, document, position):
     """Get formatted completions for current code position"""
+    # pylint: disable=too-many-locals
+    # pylint: disable=global-statement
     global _LAST_COMPLETIONS
 
     settings = config.plugin_settings('jedi_completion', document_path=document.path)
@@ -84,7 +86,7 @@ def pylsp_completions(config, document, position):
 
 
 @hookimpl
-def pylsp_completion_item_resolve(config, completion_item):
+def pylsp_completion_item_resolve(completion_item):
     """Resolve formatted completion for given non-resolved completion"""
     completion, data = _LAST_COMPLETIONS.get(completion_item['label'])
     return _resolve_completion(completion, data)

--- a/pylsp/plugins/rope_completion.py
+++ b/pylsp/plugins/rope_completion.py
@@ -12,6 +12,7 @@ log = logging.getLogger(__name__)
 # most recently retrieved completion items, used for resolution
 _LAST_COMPLETIONS = {}
 
+
 @hookimpl
 def pylsp_settings():
     # Default rope_completion to disabled
@@ -30,6 +31,8 @@ def _resolve_completion(completion, data):
 
 @hookimpl
 def pylsp_completions(config, workspace, document, position):
+    # pylint: disable=too-many-locals
+    # pylint: disable=global-statement
     global _LAST_COMPLETIONS
 
     settings = config.plugin_settings('rope_completion', document_path=document.path)
@@ -79,7 +82,7 @@ def pylsp_completions(config, workspace, document, position):
 
 
 @hookimpl
-def pyls_completion_item_resolve(config, completion_item):
+def pylsp_completion_item_resolve(completion_item):
     """Resolve formatted completion for given non-resolved completion"""
     completion, data = _LAST_COMPLETIONS.get(completion_item['label'])
     return _resolve_completion(completion, data)

--- a/pylsp/plugins/rope_completion.py
+++ b/pylsp/plugins/rope_completion.py
@@ -9,15 +9,32 @@ from pylsp import hookimpl, lsp
 
 log = logging.getLogger(__name__)
 
+# most recently retrieved completion items, used for resolution
+_LAST_COMPLETIONS = {}
 
 @hookimpl
 def pylsp_settings():
     # Default rope_completion to disabled
-    return {'plugins': {'rope_completion': {'enabled': False}}}
+    return {'plugins': {'rope_completion': {'enabled': False, 'eager': False}}}
+
+
+def _resolve_completion(completion, data):
+    try:
+        doc = data.get_doc()
+    except AttributeError:
+        doc = ""
+    completion['detail'] = '{0} {1}'.format(data.scope or "", data.name)
+    completion['documentation'] = doc
+    return completion
 
 
 @hookimpl
 def pylsp_completions(config, workspace, document, position):
+    global _LAST_COMPLETIONS
+
+    settings = config.plugin_settings('rope_completion', document_path=document.path)
+    resolve_eagerly = settings.get('eager', False)
+
     # Rope is a bit rubbish at completing module imports, so we'll return None
     word = document.word_at_position({
         # The -1 should really be trying to look at the previous word, but that might be quite expensive
@@ -41,20 +58,31 @@ def pylsp_completions(config, workspace, document, position):
     definitions = sorted_proposals(definitions)
     new_definitions = []
     for d in definitions:
-        try:
-            doc = d.get_doc()
-        except AttributeError:
-            doc = None
-        new_definitions.append({
+        item = {
             'label': d.name,
             'kind': _kind(d),
-            'detail': '{0} {1}'.format(d.scope or "", d.name),
-            'documentation': doc or "",
             'sortText': _sort_text(d)
-        })
+        }
+        if resolve_eagerly:
+            item = _resolve_completion(item, d)
+        new_definitions.append(item)
+
+    _LAST_COMPLETIONS = {
+        # label is the only required property; here it is assumed to be unique
+        completion['label']: (completion, data)
+        for completion, data in zip(new_definitions, definitions)
+    }
+
     definitions = new_definitions
 
     return definitions or None
+
+
+@hookimpl
+def pyls_completion_item_resolve(config, completion_item):
+    """Resolve formatted completion for given non-resolved completion"""
+    completion, data = _LAST_COMPLETIONS.get(completion_item['label'])
+    return _resolve_completion(completion, data)
 
 
 def _sort_text(definition):
@@ -72,7 +100,7 @@ def _sort_text(definition):
 
 
 def _kind(d):
-    """ Return the VSCode type """
+    """ Return the LSP type """
     MAP = {
         'none': lsp.CompletionItemKind.Value,
         'type': lsp.CompletionItemKind.Class,

--- a/pylsp/plugins/rope_completion.py
+++ b/pylsp/plugins/rope_completion.py
@@ -59,7 +59,10 @@ def pylsp_completions(config, workspace, document, position):
         item = {
             'label': d.name,
             'kind': _kind(d),
-            'sortText': _sort_text(d)
+            'sortText': _sort_text(d),
+            'data': {
+                'doc_uri': document.uri
+            }
         }
         if resolve_eagerly:
             item = _resolve_completion(item, d)

--- a/pylsp/python_lsp.py
+++ b/pylsp/python_lsp.py
@@ -251,7 +251,7 @@ class PythonLSPServer(MethodDispatcher):
         }
 
     def completion_item_resolve(self, completion_item):
-        return self._hook('pyls_completion_item_resolve', completion_item=completion_item)
+        return self._hook('pylsp_completion_item_resolve', completion_item=completion_item)
 
     def definitions(self, doc_uri, position):
         return flatten(self._hook('pylsp_definitions', doc_uri, position=position))

--- a/pylsp/python_lsp.py
+++ b/pylsp/python_lsp.py
@@ -251,7 +251,8 @@ class PythonLSPServer(MethodDispatcher):
         }
 
     def completion_item_resolve(self, completion_item):
-        return self._hook('pylsp_completion_item_resolve', completion_item=completion_item)
+        doc_uri = completion_item.get('data', {}).get('doc_uri', None)
+        return self._hook('pylsp_completion_item_resolve', doc_uri, completion_item=completion_item)
 
     def definitions(self, doc_uri, position):
         return flatten(self._hook('pylsp_definitions', doc_uri, position=position))

--- a/pylsp/python_lsp.py
+++ b/pylsp/python_lsp.py
@@ -162,8 +162,8 @@ class PythonLSPServer(MethodDispatcher):
                 'resolveProvider': False,  # We may need to make this configurable
             },
             'completionProvider': {
-                'resolveProvider': False,  # We know everything ahead of time
-                'triggerCharacters': ['.']
+                'resolveProvider': True,  # We could know everything ahead of time, but this takes time to transfer
+                'triggerCharacters': ['.'],
             },
             'documentFormattingProvider': True,
             'documentHighlightProvider': True,
@@ -250,6 +250,9 @@ class PythonLSPServer(MethodDispatcher):
             'items': flatten(completions)
         }
 
+    def completion_item_resolve(self, completion_item):
+        return self._hook('pyls_completion_item_resolve', completion_item=completion_item)
+
     def definitions(self, doc_uri, position):
         return flatten(self._hook('pylsp_definitions', doc_uri, position=position))
 
@@ -295,6 +298,9 @@ class PythonLSPServer(MethodDispatcher):
 
     def folding(self, doc_uri):
         return flatten(self._hook('pylsp_folding_range', doc_uri))
+
+    def m_completion_item__resolve(self, **completionItem):
+        return self.completion_item_resolve(completionItem)
 
     def m_text_document__did_close(self, textDocument=None, **_kwargs):
         workspace = self._match_uri_to_workspace(textDocument['uri'])

--- a/pylsp/workspace.py
+++ b/pylsp/workspace.py
@@ -138,6 +138,7 @@ class Document:
         self.path = uris.to_fs_path(uri)
         self.dot_path = _utils.path_to_dot_name(self.path)
         self.filename = os.path.basename(self.path)
+        self.shared_data = {}
 
         self._config = workspace._config
         self._workspace = workspace

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -158,7 +158,6 @@ def test_jedi_completion_item_resolve(config, workspace):
     assert 'detail' not in documented_hello_item
 
     resolved_documented_hello = pylsp_jedi_completion_item_resolve(
-        config,
         completion_item=documented_hello_item
     )
     assert 'Sends a polite greeting' in resolved_documented_hello['documentation']
@@ -436,7 +435,7 @@ def test_jedi_completion_environment(workspace):
     completions = pylsp_jedi_completions(doc._config, doc, com_position)
     assert completions[0]['label'] == 'loghub'
 
-    resolved = pylsp_jedi_completion_item_resolve(doc._config, completions[0])
+    resolved = pylsp_jedi_completion_item_resolve(completions[0])
     assert 'changelog generator' in resolved['documentation'].lower()
 
 

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -158,7 +158,8 @@ def test_jedi_completion_item_resolve(config, workspace):
     assert 'detail' not in documented_hello_item
 
     resolved_documented_hello = pylsp_jedi_completion_item_resolve(
-        completion_item=documented_hello_item
+        completion_item=documented_hello_item,
+        document=doc
     )
     assert 'Sends a polite greeting' in resolved_documented_hello['documentation']
 
@@ -435,7 +436,7 @@ def test_jedi_completion_environment(workspace):
     completions = pylsp_jedi_completions(doc._config, doc, com_position)
     assert completions[0]['label'] == 'loghub'
 
-    resolved = pylsp_jedi_completion_item_resolve(completions[0])
+    resolved = pylsp_jedi_completion_item_resolve(completions[0], doc)
     assert 'changelog generator' in resolved['documentation'].lower()
 
 

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -436,7 +436,7 @@ def test_jedi_completion_environment(workspace):
     completions = pylsp_jedi_completions(doc._config, doc, com_position)
     assert completions[0]['label'] == 'loghub'
 
-    resolved = pylsp_jedi_completion_item_resolve(completions[0]['documentation'])
+    resolved = pylsp_jedi_completion_item_resolve(doc._config, completions[0])
     assert 'changelog generator' in resolved['documentation'].lower()
 
 


### PR DESCRIPTION
Supersedes https://github.com/palantir/python-language-server/pull/905. Rebase of #1.

- implemented new hook for resolve
- implemented resolve in jedi_completion and rope_completion
- added `eager` option to rope_completion and jedi_completion allow users using clients which cannot yet handle `completionItem/resolve` to restore to eager resolution (inside of `textDocument/completions`)
- added test for resolve and documentation in Jedi
- tested with development version of [JupyterLab-LSP](https://github.com/krassowski/jupyterlab-lsp) client; the client implementation was tested against reference JavaScript/TypeScript server and against the R-languageserver

TODO:
- [ ] document eager for rope