### PR TITLE
Add support for flake8 per-file-ignores

### DIFF
--- a/pylsp/config/flake8_conf.py
+++ b/pylsp/config/flake8_conf.py
@@ -28,6 +28,7 @@ OPTIONS = [
     ('ignore', 'plugins.flake8.ignore', list),
     ('max-line-length', 'plugins.flake8.maxLineLength', int),
     ('select', 'plugins.flake8.select', list),
+    ('per-file-ignores', 'plugins.flake8.perFileIgnores', list),
 ]
 
 

--- a/pylsp/config/flake8_conf.py
+++ b/pylsp/config/flake8_conf.py
@@ -49,3 +49,9 @@ class Flake8Config(ConfigSource):
         files = find_parents(self.root_path, document_path, PROJECT_CONFIGS)
         config = self.read_config_from_files(files)
         return self.parse_config(config, CONFIG_KEY, OPTIONS)
+
+    @classmethod
+    def _parse_list_opt(cls, string):
+        if string.startswith("\n"):
+            return [s.strip().rstrip(",") for s in string.split("\n") if s.strip()]
+        return [s.strip() for s in string.split(",") if s.strip()]

--- a/pylsp/config/source.py
+++ b/pylsp/config/source.py
@@ -27,8 +27,8 @@ class ConfigSource:
         """Return project-level (i.e. workspace directory) configuration."""
         raise NotImplementedError()
 
-    @staticmethod
-    def read_config_from_files(files):
+    @classmethod
+    def read_config_from_files(cls, files):
         config = configparser.RawConfigParser()
         for filename in files:
             if os.path.exists(filename) and not os.path.isdir(filename):
@@ -36,55 +36,53 @@ class ConfigSource:
 
         return config
 
-    @staticmethod
-    def parse_config(config, key, options):
+    @classmethod
+    def parse_config(cls, config, key, options):
         """Parse the config with the given options."""
         conf = {}
         for source, destination, opt_type in options:
-            opt_value = _get_opt(config, key, source, opt_type)
+            opt_value = cls._get_opt(config, key, source, opt_type)
             if opt_value is not None:
-                _set_opt(conf, destination, opt_value)
+                cls._set_opt(conf, destination, opt_value)
         return conf
 
+    @classmethod
+    def _get_opt(cls, config, key, option, opt_type):
+        """Get an option from a configparser with the given type."""
+        for opt_key in [option, option.replace('-', '_')]:
+            if not config.has_option(key, opt_key):
+                continue
 
-def _get_opt(config, key, option, opt_type):
-    """Get an option from a configparser with the given type."""
-    for opt_key in [option, option.replace('-', '_')]:
-        if not config.has_option(key, opt_key):
-            continue
+            if opt_type == bool:
+                return config.getboolean(key, opt_key)
 
-        if opt_type == bool:
-            return config.getboolean(key, opt_key)
+            if opt_type == int:
+                return config.getint(key, opt_key)
 
-        if opt_type == int:
-            return config.getint(key, opt_key)
+            if opt_type == str:
+                return config.get(key, opt_key)
 
-        if opt_type == str:
-            return config.get(key, opt_key)
+            if opt_type == list:
+                return cls._parse_list_opt(config.get(key, opt_key))
 
-        if opt_type == list:
-            return _parse_list_opt(config.get(key, opt_key))
+            raise ValueError("Unknown option type: %s" % opt_type)
 
-        raise ValueError("Unknown option type: %s" % opt_type)
+    @classmethod
+    def _parse_list_opt(cls, string):
+        return [s.strip() for s in string.split(",") if s.strip()]
 
+    @classmethod
+    def _set_opt(cls, config_dict, path, value):
+        """Set the value in the dictionary at the given path if the value is not None."""
+        if value is None:
+            return
 
-def _parse_list_opt(string):
-    if string.startswith("\n"):
-        return [s.strip().rstrip(",") for s in string.split("\n") if s.strip()]
-    return [s.strip() for s in string.split(",") if s.strip()]
+        if '.' not in path:
+            config_dict[path] = value
+            return
 
+        key, rest = path.split(".", 1)
+        if key not in config_dict:
+            config_dict[key] = {}
 
-def _set_opt(config_dict, path, value):
-    """Set the value in the dictionary at the given path if the value is not None."""
-    if value is None:
-        return
-
-    if '.' not in path:
-        config_dict[path] = value
-        return
-
-    key, rest = path.split(".", 1)
-    if key not in config_dict:
-        config_dict[key] = {}
-
-    _set_opt(config_dict[key], rest, value)
+        cls._set_opt(config_dict[key], rest, value)

--- a/pylsp/config/source.py
+++ b/pylsp/config/source.py
@@ -69,6 +69,8 @@ def _get_opt(config, key, option, opt_type):
 
 
 def _parse_list_opt(string):
+    if string.startswith("\n"):
+        return [s.strip().rstrip(",") for s in string.split("\n") if s.strip()]
     return [s.strip() for s in string.split(",") if s.strip()]
 
 


### PR DESCRIPTION
This PR implements quick and dirty support for flake8's `per-file-ignores` option.

Changes to the `list`-type config parsing were necessary.  Specifically, the parsing for multiline config settings, e.g.
```config
[flake8]
ignores =
    E101,
    E102
```
needed to be altered to allow for multiple commas on a single line, because `per-file-ignores` takes a multiline list containing file names and comma separated lists of errors to be ignored:
```config
[flake8]
per-file-ignores =
    foo.py: E101, E102
    bar.py: E101
```