### PR TITLE
Identify example code blocks in docstrings and wrap in backticks

### DIFF
--- a/pylsp/_utils.py
+++ b/pylsp/_utils.py
@@ -149,9 +149,19 @@ def format_docstring(contents):
     """
     contents = contents.replace('\t', u'\u00A0' * 4)
     contents = contents.replace('  ', u'\u00A0' * 2)
-    example_snippets = re.findall(EX_SNIPPET_RE, contents)
-    for snippet in example_snippets:
-        contents = contents.replace(snippet, f"```python\n{snippet}\n```")
+
+    # If examples exist in the docstring wrap them in backticks
+    if ">>>" in contents:
+        # add an additional newline just in case the end of the
+        # docstring doesn't end in a blank line.
+        if contents[-2:] != "\n\n":
+            contents = f"{contents}\n"
+        # search for the example block regex
+        example_snippets = re.findall(EX_SNIPPET_RE, contents)
+        # wrap the snippets that were found in backticks
+        for snippet in example_snippets:
+            contents = contents.replace(snippet, f"```python\n{snippet}\n```")
+
     return contents
 
 

--- a/pylsp/_utils.py
+++ b/pylsp/_utils.py
@@ -17,6 +17,7 @@ log = logging.getLogger(__name__)
 
 EX_SNIPPET_RE = re.compile(r"\>\>\> .*(?:\r?\n(?!\r?\n).*)*")
 
+
 def debounce(interval_s, keyed_by=None):
     """Debounce calls to this function until interval_s seconds have passed."""
     def wrapper(func):

--- a/pylsp/_utils.py
+++ b/pylsp/_utils.py
@@ -6,6 +6,7 @@ import inspect
 import logging
 import os
 import pathlib
+import re
 import threading
 
 import jedi
@@ -14,6 +15,7 @@ JEDI_VERSION = jedi.__version__
 
 log = logging.getLogger(__name__)
 
+EX_SNIPPET_RE = re.compile(r"\>\>\> .*(?:\r?\n(?!\r?\n).*)*")
 
 def debounce(interval_s, keyed_by=None):
     """Debounce calls to this function until interval_s seconds have passed."""
@@ -146,6 +148,9 @@ def format_docstring(contents):
     """
     contents = contents.replace('\t', u'\u00A0' * 4)
     contents = contents.replace('  ', u'\u00A0' * 2)
+    example_snippets = re.findall(EX_SNIPPET_RE, contents)
+    for snippet in example_snippets:
+        contents = contents.replace(snippet, f"```python\n{snippet}\n```")
     return contents
 
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -94,3 +94,82 @@ def test_clip_column():
     assert _utils.clip_column(2, ['123\n', '123'], 0) == 2
     assert _utils.clip_column(3, ['123\n', '123'], 0) == 3
     assert _utils.clip_column(4, ['123\n', '123'], 1) == 3
+
+
+def test_format_docstring():
+    teststr = """\
+Examples
+--------
+Abc
+
+>>> a = 'test'
+>>> b = 5
+>>> a
+test
+>>> b + 3
+8
+
+another
+
+>>> x = np.array([1, 2, 3])
+>>> y = np.array([4, 5, 6])
+>>> x + y
+array([5, 7, 9])
+
+"""
+    resultstr = _utils.format_docstring(teststr)
+    assert resultstr == """\
+Examples
+--------
+Abc
+
+```python
+>>> a = 'test'
+>>> b = 5
+>>> a
+test
+>>> b + 3
+8
+```
+
+another
+
+```python
+>>> x = np.array([1, 2, 3])
+>>> y = np.array([4, 5, 6])
+>>> x + y
+array([5, 7, 9])
+```
+
+"""
+
+
+def test_format_docstring_missing_newline():
+    teststr = """\
+Examples
+--------
+Abc
+
+>>> a = 'test'
+>>> b = 5
+>>> a
+test
+>>> b + 3
+8
+"""
+    resultstr = _utils.format_docstring(teststr)
+    assert resultstr == """\
+Examples
+--------
+Abc
+
+```python
+>>> a = 'test'
+>>> b = 5
+>>> a
+test
+>>> b + 3
+8
+```
+
+"""


### PR DESCRIPTION
This PR adds a regex search for `>>>`, capturing all text until the next double newline and wraps the matches in backticks such that example blocks use markdowns code block syntax

Before:

```
>>> a = '5'
>>> a
5

>>> b = 5
>>> c = 10
>>> b + c
15
```

After:

    ```python
    >>> a = '5'
    >>> a
    5
    ````
    
    ````python
    >>> b = 5
    >>> c = 10
    >>> b + c
    15
    ```