### PR TITLE
Add --version CLI argument and return version in InitializeResult

### DIFF
--- a/pylsp/__main__.py
+++ b/pylsp/__main__.py
@@ -14,6 +14,7 @@ except Exception:  # pylint: disable=broad-except
 
 from .python_lsp import (PythonLSPServer, start_io_lang_server,
                          start_tcp_lang_server)
+from ._version import __version__
 
 LOG_FORMAT = "%(asctime)s {0} - %(levelname)s - %(name)s - %(message)s".format(
     time.localtime().tm_zone)
@@ -55,6 +56,10 @@ def add_arguments(parser):
     parser.add_argument(
         '-v', '--verbose', action='count', default=0,
         help="Increase verbosity of log output, overrides log config file"
+    )
+
+    parser.add_argument(
+        '-V', '--version', action='version', version='%(prog)s v' + __version__
     )
 
 

--- a/pylsp/python_lsp.py
+++ b/pylsp/python_lsp.py
@@ -14,6 +14,7 @@ from pylsp_jsonrpc.streams import JsonRpcStreamReader, JsonRpcStreamWriter
 from . import lsp, _utils, uris
 from .config import config
 from .workspace import Workspace
+from ._version import __version__
 
 log = logging.getLogger(__name__)
 
@@ -225,7 +226,13 @@ class PythonLSPServer(MethodDispatcher):
             self.watching_thread.daemon = True
             self.watching_thread.start()
         # Get our capabilities
-        return {'capabilities': self.capabilities()}
+        return {
+            'capabilities': self.capabilities(),
+            'serverInfo': {
+                'name': 'pylsp',
+                'version': __version__,
+            },
+        }
 
     def m_initialized(self, **_kwargs):
         self._hook('pylsp_initialized')


### PR DESCRIPTION
The extension of InitializeResult is especially useful in tcp mode when users want to check whether the client communicates with pyls or pylsp (or some other python language servers).

Thanks