### PR TITLE
Improve release instructions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,16 +2,16 @@ To release a new version of python-lsp-server:
 1. git fetch upstream && git checkout upstream/master
 2. Close milestone on GitHub
 3. git clean -xfdi
-4. Update CHANGELOG.md with loghub
+4. Update CHANGELOG.md with `loghub python-lsp/python-lsp-server -m vX.X.X`
 5. git add -A && git commit -m "Update Changelog"
-6. Update release version in ``_version.py`` (set release version, remove 'dev0')
+6. Update release version in `_version.py` (set release version, remove 'dev0')
 7. git add -A && git commit -m "Release vX.X.X"
 8. python setup.py sdist
 9. python setup.py bdist_wheel
-10. twine check
-11. twine upload
+10. twine check dist/*
+11. twine upload dist/*
 12. git tag -a vX.X.X -m "Release vX.X.X"
-13. Update development version in ``_version.py`` (add 'dev0' and increment minor)
+13. Update development version in `_version.py` (add 'dev0' and increment minor)
 14. git add -A && git commit -m "Back to work"
-15. git push upstream master
+15. git push upstream develop
 16. git push upstream --tags


### PR DESCRIPTION
After doing the release of `1.1.0` I noticed I could improve our instructions a bit.