### PR TITLE
Document internal flake8 plugin schema and configuration

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -12,7 +12,7 @@ This server can be configured using `workspace/didChangeConfiguration` method. E
 | `pylsp.plugins.flake8.hangClosing` | `boolean` | Hang closing bracket instead of matching indentation of opening bracket's line. | `null` |
 | `pylsp.plugins.flake8.ignore` | `array`  | List of errors and warnings to ignore (or skip). | `null` |
 | `pylsp.plugins.flake8.maxLineLength` | `integer` | Maximum allowed line length for the entirety of this run. | `null` |
-| `pylsp.plugins.flake8.perFileIgnores` | `array`  | A pairing of filenames and violation codes that defines which violations to ignore in a particular file. | `null` |
+| `pylsp.plugins.flake8.perFileIgnores` | `array`  | A pairing of filenames and violation codes that defines which violations to ignore in a particular file, for example: `["file_path.py:W305,W304"]`). | `null` |
 | `pylsp.plugins.flake8.select` | `array`  | List of errors and warnings to enable. | `null` |
 | `pylsp.plugins.jedi.extra_paths` | `array`  | Define extra paths for jedi.Script. | `[]` |
 | `pylsp.plugins.jedi.env_vars` | `object` | Define environment variables for jedi.Script and Jedi.names. | `null` |

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -4,6 +4,16 @@ This server can be configured using `workspace/didChangeConfiguration` method. E
 | **Configuration Key** | **Type** | **Description** | **Default** 
 |----|----|----|----|
 | `pylsp.configurationSources` | `array`  of unique `string` items | List of configuration sources to use. | `["pycodestyle"]` |
+| `pylsp.plugins.flake8.config` | `string` | Path to the config file that will be the authoritative config source. | `null` |
+| `pylsp.plugins.flake8.enabled` | `boolean` | Enable or disable the plugin. | `false` |
+| `pylsp.plugins.flake8.exclude` | `array`  | List of files or directories to exclude. | `null` |
+| `pylsp.plugins.flake8.executable` | `string` | Path to the flake8 executable. | `"flake8"` |
+| `pylsp.plugins.flake8.filename` | `string` | Only check for filenames matching the patterns in this list. | `null` |
+| `pylsp.plugins.flake8.hangClosing` | `boolean` | Hang closing bracket instead of matching indentation of opening bracket's line. | `null` |
+| `pylsp.plugins.flake8.ignore` | `array`  | List of errors and warnings to ignore (or skip). | `null` |
+| `pylsp.plugins.flake8.maxLineLength` | `integer` | Maximum allowed line length for the entirety of this run. | `null` |
+| `pylsp.plugins.flake8.perFileIgnores` | `array`  | A pairing of filenames and violation codes that defines which violations to ignore in a particular file. | `null` |
+| `pylsp.plugins.flake8.select` | `array`  | List of errors and warnings to enable. | `null` |
 | `pylsp.plugins.jedi.extra_paths` | `array`  | Define extra paths for jedi.Script. | `[]` |
 | `pylsp.plugins.jedi.env_vars` | `object` | Define environment variables for jedi.Script and Jedi.names. | `null` |
 | `pylsp.plugins.jedi.environment` | `string` | Define environment for jedi.Script and Jedi.names. | `null` |

--- a/pylsp/config/schema.json
+++ b/pylsp/config/schema.json
@@ -14,6 +14,56 @@
       },
       "uniqueItems": true
     },
+    "pylsp.plugins.flake8.config": {
+      "type": "string",
+      "default": null,
+      "description": "Path to the config file that will be the authoritative config source."
+    },
+    "pylsp.plugins.flake8.enabled": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable or disable the plugin."
+    },
+    "pylsp.plugins.flake8.exclude": {
+      "type": "array",
+      "default": null,
+      "description": "List of files or directories to exclude."
+    },
+    "pylsp.plugins.flake8.executable": {
+      "type": "string",
+      "default": "flake8",
+      "description": "Path to the flake8 executable."
+    },
+    "pylsp.plugins.flake8.filename": {
+      "type": "string",
+      "default": null,
+      "description": "Only check for filenames matching the patterns in this list."
+    },
+    "pylsp.plugins.flake8.hangClosing": {
+      "type": "boolean",
+      "default": null,
+      "description": "Hang closing bracket instead of matching indentation of opening bracket's line."
+    },
+    "pylsp.plugins.flake8.ignore": {
+      "type": "array",
+      "default": null,
+      "description": "List of errors and warnings to ignore (or skip)."
+    },
+    "pylsp.plugins.flake8.maxLineLength": {
+      "type": "integer",
+      "default": null,
+      "description": "Maximum allowed line length for the entirety of this run."
+    },
+    "pylsp.plugins.flake8.perFileIgnores": {
+      "type": "array",
+      "default": null,
+      "description": "A pairing of filenames and violation codes that defines which violations to ignore in a particular file."
+    },
+    "pylsp.plugins.flake8.select": {
+      "type": "array",
+      "default": null,
+      "description": "List of errors and warnings to enable."
+    },
     "pylsp.plugins.jedi.extra_paths": {
       "type": "array",
       "default": [],

--- a/pylsp/config/schema.json
+++ b/pylsp/config/schema.json
@@ -57,7 +57,7 @@
     "pylsp.plugins.flake8.perFileIgnores": {
       "type": "array",
       "default": null,
-      "description": "A pairing of filenames and violation codes that defines which violations to ignore in a particular file."
+      "description": "A pairing of filenames and violation codes that defines which violations to ignore in a particular file, for example: `[\"file_path.py:W305,W304\"]`)."
     },
     "pylsp.plugins.flake8.select": {
       "type": "array",


### PR DESCRIPTION
Note-to-self: Take more time to read the comments from the maintainers. I spent 15 mins syncing manually the `schema.json` and the `CONFIGURATION.md` until I realized @krassowski already shared a script to do that automagically :sweat_smile: 

```shell
# from https://github.com/python-lsp/python-lsp-server#development
python scripts/jsonschema2md.py pylsp/config/schema.json CONFIGURATION.md
```

Closes #55 