### PR TITLE
Recognize the "I" pylint stdio message category

### DIFF
--- a/pylsp/plugins/pylint_lint.py
+++ b/pylsp/plugins/pylint_lint.py
@@ -280,6 +280,7 @@ def _parse_pylint_stdio_result(document, stdout):
             'C': lsp.DiagnosticSeverity.Information,
             'E': lsp.DiagnosticSeverity.Error,
             'F': lsp.DiagnosticSeverity.Error,
+            'I': lsp.DiagnosticSeverity.Information,
             'R': lsp.DiagnosticSeverity.Hint,
             'W': lsp.DiagnosticSeverity.Warning,
         }


### PR DESCRIPTION
This category includes messages such as `c-extension-no-member`,
`use-symbolic-message-instead`, `useless-suppression` and others (only
the first one mentioned is enabled by default).  This commit fixes
parsing of stdio linting results when such a message is emitted.