### PR TITLE
Fix pylint test without pylsp installed

### DIFF
--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -82,7 +82,9 @@ def workspace_other_root_path(tmpdir):
 @pytest.fixture
 def config(workspace):  # pylint: disable=redefined-outer-name
     """Return a config object."""
-    return Config(workspace.root_uri, {}, 0, {})
+    cfg = Config(workspace.root_uri, {}, 0, {})
+    cfg._plugin_settings = {'plugins': {'pylint': {'enabled': False, 'args': [], 'executable': None}}}
+    return cfg
 
 
 @pytest.fixture


### PR DESCRIPTION
In case pylsp is not installed, the pylint plugin is not found in
Config.__init__ and Config._plugin_settings is empty. This is
fine except test_pylint_lint.test_pylint tries to set the pylint
executable in the settings. This patch works around this by patching in
the config.