### PR TITLE
Document how to write python-lsp-server plugin + add pylsp-rope to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Installing these plugins will add extra functionality to the language server:
 - [pyls-isort](https://github.com/paradoxxxzero/pyls-isort): code formatting using [isort](https://github.com/PyCQA/isort) (automatic import sorting).
 - [python-lsp-black](https://github.com/python-lsp/python-lsp-black): code formatting using [Black](https://github.com/psf/black).
 - [pyls-memestra](https://github.com/QuantStack/pyls-memestra): detecting the use of deprecated APIs.
-- [pylsp-rope](https://github.com/python-rope/pylsp-rope): Extended refactoring capabilities using Rope.
+- [pylsp-rope](https://github.com/python-rope/pylsp-rope): Extended refactoring capabilities using [Rope](https://github.com/python-rope/rope).
 
 Please see the above repositories for examples on how to write plugins for the Python LSP Server.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,11 @@ Installing these plugins will add extra functionality to the language server:
 - [python-lsp-black](https://github.com/python-lsp/python-lsp-black): code formatting using [Black](https://github.com/psf/black).
 - [pyls-memestra](https://github.com/QuantStack/pyls-memestra): detecting the use of deprecated APIs.
 
-Please see the above repositories for examples on how to write plugins for the Python LSP Server. Please file an issue if you require assistance writing a plugin.
+Please see the above repositories for examples on how to write plugins for the Python LSP Server.
+
+[cookiecutter-pylsp-plugin](https://github.com/lieryan/cookiecutter-pylsp-plugin) is a [cookiecutter](https://cookiecutter.readthedocs.io/) template that sets up a basic plugin project for python-lsp-server. It documents how to write your own plugins.
+
+Please file an issue if you require assistance writing a plugin.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -48,10 +48,11 @@ Installing these plugins will add extra functionality to the language server:
 - [pyls-isort](https://github.com/paradoxxxzero/pyls-isort): code formatting using [isort](https://github.com/PyCQA/isort) (automatic import sorting).
 - [python-lsp-black](https://github.com/python-lsp/python-lsp-black): code formatting using [Black](https://github.com/psf/black).
 - [pyls-memestra](https://github.com/QuantStack/pyls-memestra): detecting the use of deprecated APIs.
+- [pylsp-rope](https://github.com/python-rope/pylsp-rope): Extended refactoring capabilities using Rope.
 
 Please see the above repositories for examples on how to write plugins for the Python LSP Server.
 
-[cookiecutter-pylsp-plugin](https://github.com/lieryan/cookiecutter-pylsp-plugin) is a [cookiecutter](https://cookiecutter.readthedocs.io/) template that sets up a basic plugin project for python-lsp-server. It documents how to write your own plugins.
+[cookiecutter-pylsp-plugin](https://github.com/lieryan/cookiecutter-pylsp-plugin) is a [cookiecutter](https://cookiecutter.readthedocs.io/) template for setting up a basic plugin project for python-lsp-server. It documents all the essentials you need to know to kick start your own plugin project.
 
 Please file an issue if you require assistance writing a plugin.
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Installing these plugins will add extra functionality to the language server:
 
 Please see the above repositories for examples on how to write plugins for the Python LSP Server.
 
-[cookiecutter-pylsp-plugin](https://github.com/lieryan/cookiecutter-pylsp-plugin) is a [cookiecutter](https://cookiecutter.readthedocs.io/) template for setting up a basic plugin project for python-lsp-server. It documents all the essentials you need to know to kick start your own plugin project.
+[cookiecutter-pylsp-plugin](https://github.com/python-lsp/cookiecutter-pylsp-plugin) is a [cookiecutter](https://cookiecutter.readthedocs.io/) template for setting up a basic plugin project for python-lsp-server. It documents all the essentials you need to know to kick start your own plugin project.
 
 Please file an issue if you require assistance writing a plugin.
 


### PR DESCRIPTION
Currently, writing a plugin for python-lsp-server is rather difficult, there is very little documentation on how to do this other than just a short pointer to "see [existing plugins] for examples on how to write plugins". 

There's quite a number of non-obvious knowledge that one has to know, which is quite an impediment for people wanting to write plugins. I wanted to change that, so I've written a [cookiecutter](https://cookiecutter.readthedocs.io/) template that aims to make it much easier to start a pylsp plugin project and also aims to document how to write plugins in more depth.

Ideally, I think python-lsp-server documentation should be owned by python-lsp's organisation rather than in my own repository, so I'd request if python-lsp-server core maintainers are interested in this project, to help adopt the project into the python-lsp Github Organisation, so it can be maintained by the community rather than as an external project on my user's namespace.

The primary test case for this template is [pylsp-rope](https://github.com/python-rope/pylsp-rope), which is the first pylsp plugin written to use the template and the main driver for me wanting to write a python-lsp-server plugin. Also, this just happens to be the first public announcement of pylsp-rope, so I'm also quite excited to announce that now you can use [Rope](https://github.com/python-rope/rope) from an LSP, beyond the basic renaming and completion that exists in the current built-in Rope support. 