### PR TITLE
Remove pyqt5 dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
         'rope': ['rope>0.10.5'],
         'yapf': ['yapf'],
         'test': ['pylint>=2.5.0', 'pytest', 'pytest-cov', 'coverage',
-                 'numpy', 'pandas', 'matplotlib', 'pyqt5', 'flaky'],
+                 'numpy', 'pandas', 'matplotlib', 'flaky'],
     },
     entry_points={
         'console_scripts': [

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -264,18 +264,6 @@ def test_jedi_method_completion(config, workspace):
     assert everyone_method['insertText'] == 'everyone'
 
 
-@pytest.mark.skipif(PY2 or (sys.platform.startswith('linux') and os.environ.get('CI') is not None),
-                    reason="Test in Python 3 and not on CIs on Linux because wheels don't work on them.")
-def test_pyqt_completion(config, workspace):
-    # Over 'QA' in 'from PyQt5.QtWidgets import QApplication'
-    doc_pyqt = "from PyQt5.QtWidgets import QA"
-    com_position = {'line': 0, 'character': len(doc_pyqt)}
-    doc = Document(DOC_URI, workspace, doc_pyqt)
-    completions = pylsp_jedi_completions(config, doc, com_position)
-
-    assert completions is not None
-
-
 def test_numpy_completions(config, workspace):
     doc_numpy = "import numpy as np; np."
     com_position = {'line': 0, 'character': len(doc_numpy)}


### PR DESCRIPTION
Hello,

I'm using nix on macOS and because of the qt dependency all of qt is being pulled in. Because of a pin on an old LLVM version I can't install python-lsp-server. I'm hoping that it's okay if you can remove the dependency without which the build will be much smaller and won't break because of the C compiler version.