### PR TITLE
Fix test_syntax_error_pylint_py3 for Python 3.10

### DIFF
--- a/test/plugins/test_pylint_lint.py
+++ b/test/plugins/test_pylint_lint.py
@@ -84,7 +84,10 @@ def test_syntax_error_pylint_py3(config, workspace):
         config.plugin_settings('pylint')['executable'] = 'pylint'
         diag = pylint_lint.pylsp_lint(config, doc, True)[0]
 
-        assert diag['message'].startswith('invalid syntax')
+        if sys.version_info[:2] >= (3, 10):
+            assert diag['message'].count("expected ':'")
+        else:
+            assert diag['message'].startswith('invalid syntax')
         # Pylint doesn't give column numbers for invalid syntax.
         assert diag['range']['start'] == {'line': 0, 'character': 12}
         assert diag['severity'] == lsp.DiagnosticSeverity.Error


### PR DESCRIPTION
The PR at https://github.com/python-lsp/python-lsp-server/pull/112 was supposed to fix this test, but actually it still does not work for me on python 3.10:
```
_________________________ test_syntax_error_pylint_py3 _________________________

config = <pylsp.config.config.Config object at 0x7faa011ea590>
workspace = <pylsp.workspace.Workspace object at 0x7faa01185360>

    @py3_only
    def test_syntax_error_pylint_py3(config, workspace):
        with temp_document(DOC_SYNTAX_ERR, workspace) as doc:
            diag = pylint_lint.pylsp_lint(config, doc, True)[0]
    
            if sys.version_info[:2] >= (3, 10):
                assert diag['message'].count("[syntax-error] expected ':'")
            else:
                assert diag['message'].startswith('[syntax-error] invalid syntax')
            # Pylint doesn't give column numbers for invalid syntax.
            assert diag['range']['start'] == {'line': 0, 'character': 12}
            assert diag['severity'] == lsp.DiagnosticSeverity.Error
    
            # test running pylint in stdin
            config.plugin_settings('pylint')['executable'] = 'pylint'
            diag = pylint_lint.pylsp_lint(config, doc, True)[0]
    
>           assert diag['message'].startswith('invalid syntax')
E           assert False
E            +  where False = <built-in method startswith of str object at 0x7fa9fbb18ff0>('invalid syntax')
E            +    where <built-in method startswith of str object at 0x7fa9fbb18ff0> = "expected ':' (<unknown>, line 1) (syntax-error)".startswith

test/plugins/test_pylint_lint.py:87: AssertionError
---------------------------- Captured stderr setup -----------------------------
2021-12-05 15:04:53,587 UTC - DEBUG - pylsp.config.config -   pylsp_settings [hook]
      config: <pylsp.config.config.Config object at 0x7faa01184f10>

2021-12-05 15:04:53,587 UTC - DEBUG - pylsp.config.config -   finish pylsp_settings --> [] [hook]

2021-12-05 15:04:53,587 UTC - INFO - pylsp.config.config - Disabled plugins: []
2021-12-05 15:04:53,593 UTC - DEBUG - pylsp.config.config -   pylsp_settings [hook]
      config: <pylsp.config.config.Config object at 0x7faa011ea590>

2021-12-05 15:04:53,593 UTC - DEBUG - pylsp.config.config -   finish pylsp_settings --> [] [hook]

2021-12-05 15:04:53,593 UTC - INFO - pylsp.config.config - Disabled plugins: []
------------------------------ Captured log setup ------------------------------
DEBUG    pylsp.config.config:_tracing.py:34   pylsp_settings [hook]
      config: <pylsp.config.config.Config object at 0x7faa01184f10>

DEBUG    pylsp.config.config:_tracing.py:34   finish pylsp_settings --> [] [hook]

INFO     pylsp.config.config:config.py:156 Disabled plugins: []
DEBUG    pylsp.config.config:_tracing.py:34   pylsp_settings [hook]
      config: <pylsp.config.config.Config object at 0x7faa011ea590>

DEBUG    pylsp.config.config:_tracing.py:34   finish pylsp_settings --> [] [hook]

INFO     pylsp.config.config:config.py:156 Disabled plugins: []
----------------------------- Captured stderr call -----------------------------
2021-12-05 15:04:53,594 UTC - DEBUG - pylsp.config.config - Got user config from PyCodeStyleConfig: {}
2021-12-05 15:04:53,595 UTC - DEBUG - pylsp.config.config - Got project config from PyCodeStyleConfig: {}
2021-12-05 15:04:53,595 UTC - DEBUG - pylsp.config.config - With configuration: {'plugins': {'pylint': {'enabled': False, 'args': [], 'executable': None}}}
2021-12-05 15:04:53,595 UTC - DEBUG - pylsp.plugins.pylint_lint - Got pylint settings: {'enabled': False, 'args': [], 'executable': None}
2021-12-05 15:04:53,595 UTC - DEBUG - pylsp.plugins.pylint_lint - Calling pylint with '/tmp/tmp_su622bf -f json '
2021-12-05 15:04:54,125 UTC - DEBUG - pylsp.plugins.pylint_lint - Got pylint settings: {'enabled': False, 'args': [], 'executable': 'pylint'}
2021-12-05 15:04:54,125 UTC - DEBUG - pylsp.plugins.pylint_lint - Calling pylint with args: '[]'
2021-12-05 15:04:54,647 UTC - DEBUG - pylsp.plugins.pylint_lint - Pylint output parser can't parse line '************* Module tmp_su622bf'
------------------------------ Captured log call -------------------------------
DEBUG    pylsp.config.config:config.py:120 Got user config from PyCodeStyleConfig: {}
DEBUG    pylsp.config.config:config.py:129 Got project config from PyCodeStyleConfig: {}
DEBUG    pylsp.config.config:config.py:132 With configuration: {'plugins': {'pylint': {'enabled': False, 'args': [], 'executable': None}}}
DEBUG    pylsp.plugins.pylint_lint:pylint_lint.py:174 Got pylint settings: {'enabled': False, 'args': [], 'executable': None}
DEBUG    pylsp.plugins.pylint_lint:pylint_lint.py:72 Calling pylint with '/tmp/tmp_su622bf -f json '
DEBUG    pylsp.plugins.pylint_lint:pylint_lint.py:174 Got pylint settings: {'enabled': False, 'args': [], 'executable': 'pylint'}
DEBUG    pylsp.plugins.pylint_lint:pylint_lint.py:234 Calling pylint with args: '[]'
DEBUG    pylsp.plugins.pylint_lint:pylint_lint.py:268 Pylint output parser can't parse line '************* Module tmp_su622bf'
```

Looking at the previous change and the reported error, I’ve figured out this should be the proper fix.