### PR TITLE
Prefer YAPF over autopep8

### DIFF
--- a/pylsp/plugins/autopep8_format.py
+++ b/pylsp/plugins/autopep8_format.py
@@ -9,13 +9,13 @@ from pylsp import hookimpl
 log = logging.getLogger(__name__)
 
 
-@hookimpl(tryfirst=True)  # Prefer autopep8 over YAPF
+@hookimpl
 def pylsp_format_document(config, document):
     log.info("Formatting document %s with autopep8", document)
     return _format(config, document)
 
 
-@hookimpl(tryfirst=True)  # Prefer autopep8 over YAPF
+@hookimpl
 def pylsp_format_range(config, document, range):  # pylint: disable=redefined-builtin
     log.info("Formatting document %s in range %s with autopep8", document, range)
 

--- a/pylsp/plugins/yapf_format.py
+++ b/pylsp/plugins/yapf_format.py
@@ -10,12 +10,12 @@ from pylsp import hookimpl
 log = logging.getLogger(__name__)
 
 
-@hookimpl
+@hookimpl(tryfirst=True)  # Prefer YAPF over autopep8
 def pylsp_format_document(document):
     return _format(document)
 
 
-@hookimpl
+@hookimpl(tryfirst=True)  # Prefer YAPF over autopep8
 def pylsp_format_range(document, range):  # pylint: disable=redefined-builtin
     # First we 'round' the range up/down to full lines only
     range['start']['character'] = 0


### PR DESCRIPTION
YAPF is a real formatter where-as autopep8 is more of a lint fixer. See the YAPF readme https://github.com/google/yapf, see also discussion here https://github.com/palantir/python-language-server/issues/328

The other reason is that I will be improving YAPF support, starting with adding support for protocol's formatting options (see https://github.com/python-lsp/python-lsp-server/pull/134) and then following up with sending actual text edits using yapf unidiff output format instead of the whole document https://github.com/python-lsp/python-lsp-server/blob/develop/pylsp/plugins/yapf_format.py#L49-L58