### PR TITLE
Add license info to `setup.py` so it will show up in wheel installs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,8 @@ description = Python Language Server for the Language Server Protocol
 url = https://github.com/python-lsp/python-lsp-server
 long_description = file: README.md
 long_description_content_type = text/markdown
+license = MIT
+license_file = LICENSE
 
 [options]
 packages = find:


### PR DESCRIPTION
Just unable to see the license info from packaging. This will correct that.