### PR TITLE
PR: Put user provided paths at the front of sys.path

### DIFF
--- a/pylsp/workspace.py
+++ b/pylsp/workspace.py
@@ -263,12 +263,14 @@ class Document:
         env_vars.pop('PYTHONPATH', None)
 
         environment = self.get_enviroment(environment_path, env_vars=env_vars) if environment_path else None
-        sys_path = self.sys_path(environment_path, env_vars=env_vars) + extra_paths
         project_path = self._workspace.root_path
+
+        # User provided paths should take priority
+        sys_path = extra_paths + self.sys_path(environment_path, env_vars=env_vars)
 
         # Extend sys_path with document's path if requested
         if use_document_path:
-            sys_path += [os.path.normpath(os.path.dirname(self.path))]
+            sys_path.insert(0, os.path.normpath(os.path.dirname(self.path)))
 
         kwargs = {
             'code': self.source,


### PR DESCRIPTION
Put user provided paths (via extra_paths) at the front of sys.path instead of the back.

Similarly for the document path, if requested.
Completions search path is then: Document.path + extra_paths + Document._extra_sys_path + environment sys.path

See spyder-ide/spyder#17066