### PR TITLE
Add `DiagnosticTag` constants from LSP 3.15

### DIFF
--- a/pylsp/lsp.py
+++ b/pylsp/lsp.py
@@ -48,6 +48,11 @@ class DiagnosticSeverity:
     Hint = 4
 
 
+class DiagnosticTag:
+    Unnecessary = 1
+    Deprecated = 2
+
+
 class InsertTextFormat:
     PlainText = 1
     Snippet = 2


### PR DESCRIPTION
Add ([`DiagnosticTag`](https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#diagnosticTag)) constants from LSP 3.15 to allow plugins like memestra to re-use them (https://github.com/QuantStack/pyls-memestra/issues/52).