### PR TITLE
Fix Autopep8 and Yapf formatting with CR line endings

### DIFF
--- a/pylsp/_utils.py
+++ b/pylsp/_utils.py
@@ -225,11 +225,13 @@ else:
             return True
 
 
+import re
+
+EOL_REGEX = re.compile(f'({"|".join(EOL_CHARS)})')
+
 def get_eol_chars(text):
     """Get EOL chars used in text."""
-    for eol_chars in EOL_CHARS:
-        if text.find(eol_chars) > -1:
-            break
-    else:
-        return None
-    return eol_chars
+    match = EOL_REGEX.search(text)
+    if match:
+        return match.group(0)
+    return None

--- a/pylsp/_utils.py
+++ b/pylsp/_utils.py
@@ -6,6 +6,7 @@ import inspect
 import logging
 import os
 import pathlib
+import re
 import threading
 
 import jedi
@@ -14,6 +15,7 @@ JEDI_VERSION = jedi.__version__
 
 # Eol chars accepted by the LSP protocol
 EOL_CHARS = ['\r\n', '\r', '\n']
+EOL_REGEX = re.compile(f'({"|".join(EOL_CHARS)})')
 
 log = logging.getLogger(__name__)
 
@@ -224,10 +226,6 @@ else:
         else:
             return True
 
-
-import re
-
-EOL_REGEX = re.compile(f'({"|".join(EOL_CHARS)})')
 
 def get_eol_chars(text):
     """Get EOL chars used in text."""

--- a/pylsp/_utils.py
+++ b/pylsp/_utils.py
@@ -12,6 +12,9 @@ import jedi
 
 JEDI_VERSION = jedi.__version__
 
+# Eol chars accepted by the LSP protocol
+EOL_CHARS = ['\r\n', '\r', '\n']
+
 log = logging.getLogger(__name__)
 
 
@@ -220,3 +223,13 @@ else:
             return e.errno == errno.EPERM
         else:
             return True
+
+
+def get_eol_chars(text):
+    """Get EOL chars used in text."""
+    for eol_chars in EOL_CHARS:
+        if text.find(eol_chars) > -1:
+            break
+    else:
+        return None
+    return eol_chars

--- a/pylsp/plugins/autopep8_format.py
+++ b/pylsp/plugins/autopep8_format.py
@@ -2,9 +2,12 @@
 # Copyright 2021- Python Language Server Contributors.
 
 import logging
+
 import pycodestyle
 from autopep8 import fix_code, continued_indentation as autopep8_c_i
+
 from pylsp import hookimpl
+from pylsp._utils import get_eol_chars
 
 log = logging.getLogger(__name__)
 
@@ -38,14 +41,26 @@ def _format(config, document, line_range=None):
     del pycodestyle._checks['logical_line'][pycodestyle.continued_indentation]
     pycodestyle.register_check(autopep8_c_i)
 
-    new_source = fix_code(document.source, options=options)
+    # Autopep8 doesn't work with CR line endings, so we replace them by '\n'
+    # and restore them below.
+    replace_cr = False
+    source = document.source
+    eol_chars = get_eol_chars(source)
+    if eol_chars == '\r':
+        replace_cr = True
+        source = source.replace('\r', '\n')
+
+    new_source = fix_code(source, options=options)
 
     # Switch it back
     del pycodestyle._checks['logical_line'][autopep8_c_i]
     pycodestyle.register_check(pycodestyle.continued_indentation)
 
-    if new_source == document.source:
+    if new_source == source:
         return []
+
+    if replace_cr:
+        new_source = new_source.replace('\n', '\r')
 
     # I'm too lazy at the moment to parse diffs into TextEdit items
     # So let's just return the entire file...

--- a/pylsp/plugins/yapf_format.py
+++ b/pylsp/plugins/yapf_format.py
@@ -3,9 +3,12 @@
 
 import logging
 import os
+
 from yapf.yapflib import file_resources
 from yapf.yapflib.yapf_api import FormatCode
+
 from pylsp import hookimpl
+from pylsp._utils import get_eol_chars
 
 log = logging.getLogger(__name__)
 
@@ -34,8 +37,17 @@ def pylsp_format_range(document, range):  # pylint: disable=redefined-builtin
 
 
 def _format(document, lines=None):
+    # Yapf doesn't work with CR line endings, so we replace them by '\n'
+    # and restore them below.
+    replace_cr = False
+    source = document.source
+    eol_chars = get_eol_chars(source)
+    if eol_chars == '\r':
+        replace_cr = True
+        source = source.replace('\r', '\n')
+
     new_source, changed = FormatCode(
-        document.source,
+        source,
         lines=lines,
         filename=document.filename,
         style_config=file_resources.GetDefaultStyleForDir(
@@ -45,6 +57,9 @@ def _format(document, lines=None):
 
     if not changed:
         return []
+
+    if replace_cr:
+        new_source = new_source.replace('\n', '\r')
 
     # I'm too lazy at the moment to parse diffs into TextEdit items
     # So let's just return the entire file...

--- a/test/plugins/test_autopep8_format.py
+++ b/test/plugins/test_autopep8_format.py
@@ -71,3 +71,10 @@ def test_hanging_indentation(config, workspace):
 
     assert len(res) == 1
     assert res[0]['newText'] == CORRECT_INDENTED_DOC
+
+
+def test_cr_line_endings(config, workspace):
+    doc = Document(DOC_URI, workspace, 'import os;import sys\r\rdict(a=1)')
+    res = pylsp_format_document(config, doc)
+
+    assert res[0]['newText'] == 'import os\rimport sys\r\rdict(a=1)\r'

--- a/test/plugins/test_yapf_format.py
+++ b/test/plugins/test_yapf_format.py
@@ -58,3 +58,10 @@ def test_config_file(tmpdir, workspace):
 
     # A was split on multiple lines because of column_limit from config file
     assert pylsp_format_document(doc)[0]['newText'] == "A = [\n    'h', 'w',\n    'a'\n]\n\nB = ['h', 'w']\n"
+
+
+def test_cr_line_endings(workspace):
+    doc = Document(DOC_URI, workspace, 'import os;import sys\r\rdict(a=1)')
+    res = pylsp_format_document(doc)
+
+    assert res[0]['newText'] == 'import os\rimport sys\r\rdict(a=1)\r'


### PR DESCRIPTION
- Both formatters fail with those line endings (i.e. `\r`).
- We need to fix this on our side because the LSP spec support files with CR endings, as described [here](https://microsoft.github.io/language-server-protocol/specification#textDocuments).
- I found this while investigating the error reported in spyder-ide/spyder#17143.