### PR TITLE
Prevent faulty third-party plugins to crash the server

### DIFF
--- a/pylsp/config/config.py
+++ b/pylsp/config/config.py
@@ -50,7 +50,7 @@ class Config:
         for entry_point in pkg_resources.iter_entry_points(PYLSP):
             try:
                 entry_point.load()
-            except (ImportError, pkg_resources.DistributionNotFound) as e:
+            except Exception as e:
                 log.warning("Failed to load %s entry point '%s': %s", PYLSP, entry_point.name, e)
                 self._pm.set_blocked(entry_point.name)
 

--- a/pylsp/config/config.py
+++ b/pylsp/config/config.py
@@ -50,7 +50,7 @@ class Config:
         for entry_point in pkg_resources.iter_entry_points(PYLSP):
             try:
                 entry_point.load()
-            except Exception as e:
+            except Exception as e:  # pylint: disable=broad-except
                 log.warning("Failed to load %s entry point '%s': %s", PYLSP, entry_point.name, e)
                 self._pm.set_blocked(entry_point.name)
 

--- a/pylsp/config/config.py
+++ b/pylsp/config/config.py
@@ -50,7 +50,7 @@ class Config:
         for entry_point in pkg_resources.iter_entry_points(PYLSP):
             try:
                 entry_point.load()
-            except ImportError as e:
+            except (ImportError, pkg_resources.DistributionNotFound) as e:
                 log.warning("Failed to load %s entry point '%s': %s", PYLSP, entry_point.name, e)
                 self._pm.set_blocked(entry_point.name)
 


### PR DESCRIPTION
I'm using this in spyder. There on loading pylsp-black, I get this error:

```
  File "C:\Program Files\Python39\lib\site-packages\pylsp_jsonrpc\endpoint.py", line 116, in consume
    self._handle_request(message['id'], message['method'], message.get('params'))
  File "C:\Program Files\Python39\lib\site-packages\pylsp_jsonrpc\endpoint.py", line 185, in _handle_request
    handler_result = handler(params)
  File "C:\Program Files\Python39\lib\site-packages\pylsp_jsonrpc\dispatchers.py", line 25, in handler
    return method(**(params or {}))
  File "C:\Program Files\Python39\lib\site-packages\pylsp\python_lsp.py", line 210, in m_initialize
    self.config = config.Config(rootUri, initializationOptions or {},
  File "C:\Program Files\Python39\lib\site-packages\pylsp\config\config.py", line 52, in __init__
    entry_point.load()
  File "C:\Program Files\Python39\lib\site-packages\pkg_resources\__init__.py", line 2449, in load
    self.require(*args, **kwargs)
  File "C:\Program Files\Python39\lib\site-packages\pkg_resources\__init__.py", line 2472, in require
    items = working_set.resolve(reqs, env, installer, extras=self.extras)
  File "C:\Program Files\Python39\lib\site-packages\pkg_resources\__init__.py", line 772, in resolve
    raise DistributionNotFound(req, requirers)

pkg_resources.DistributionNotFound: The 'toml' distribution was not found and is required by the application
```

Which prevents LSP to start (in the status bar, LSP starting spins indefenitely) 
not sure why it's not the expected ImportError, but when also catching the pkg_resources.DistributionNotFound spyder seems to work correctly minus the LSP plugin.
Not sure whether this is the way to go, but it seems to me in the spirit of the context, that is catching plugin's errors on loading.