### PR TITLE
Add plugins for pylint and flake8 to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ If the respective dependencies are found, the following optional providers will 
 - [pydocstyle](https://github.com/PyCQA/pydocstyle) linter for docstring style checking (disabled by default)
 - [autopep8](https://github.com/hhatto/autopep8) for code formatting
 - [YAPF](https://github.com/google/yapf) for code formatting (preferred over autopep8)
+- [flake8](https://github.com/pycqa/flake8) for error checking (disabled by default)
+- [pylint](https://github.com/PyCQA/pylint) for code linting (disabled by default)
 
 Optional providers can be installed using the `extras` syntax. To install [YAPF](https://github.com/google/yapf) formatting for example:
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ If the respective dependencies are found, the following optional providers will 
 - [YAPF](https://github.com/google/yapf) for code formatting (preferred over autopep8)
 - [flake8](https://github.com/pycqa/flake8) for error checking (disabled by default)
 - [pylint](https://github.com/PyCQA/pylint) for code linting (disabled by default)
+- [preload](https://github.com/tfiers/preload) for heavy modules (not included by default)
 
 Optional providers can be installed using the `extras` syntax. To install [YAPF](https://github.com/google/yapf) formatting for example:
 


### PR DESCRIPTION
Not sure if I should add since it isn't in extras.
- [preload](https://github.com/tfiers/preload) for heavy modules