### PR TITLE
Set max line length for Pycodestyle with a configuration file

### DIFF
--- a/.pycodestyle
+++ b/.pycodestyle
@@ -1,0 +1,2 @@
+[pycodestyle]
+max-line-length = 120


### PR DESCRIPTION
Pycodestyle started to give errors because it assumes a max line length of 79 but we use 120 as default in this repo.