### PR TITLE
Restore the copyright headers in `setup.cfg` and `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+# Copyright 2017-2020 Palantir Technologies, Inc.
+# Copyright 2021- Python Language Server Contributors.
+
 [build-system]
 requires = ["setuptools>=61.2.0", "wheel", "setuptools_scm[toml]>=3.4.3"]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+# Copyright 2017-2020 Palantir Technologies, Inc.
+# Copyright 2021- Python Language Server Contributors.
+
 [pycodestyle]
 ignore = E226, E722, W504
 max-line-length = 120


### PR DESCRIPTION
accidentially not kept during semi-automatic conversions.