### PR TITLE
Change severity level for flake8 errors

### DIFF
--- a/pylsp/plugins/flake8_lint.py
+++ b/pylsp/plugins/flake8_lint.py
@@ -173,6 +173,9 @@ def parse_stdout(document, stdout):
         character = int(character) - 1
         # show also the code in message
         msg = code + ' ' + msg
+        severity = lsp.DiagnosticSeverity.Warning
+        if code[0] == "E":
+            severity = lsp.DiagnosticSeverity.Error
         diagnostics.append(
             {
                 'source': 'flake8',
@@ -189,7 +192,7 @@ def parse_stdout(document, stdout):
                     }
                 },
                 'message': msg,
-                'severity': lsp.DiagnosticSeverity.Warning,
+                'severity': severity,
             }
         )
 


### PR DESCRIPTION
See #220. The severity flag for all flake8 diagnostics are declared as warning. With this PR, all flake8 messages starting with "E" (includes messages from pycodestyle) are parsed with error severity level.

Fixes #220 