### PR TITLE
Add autopep8.enabled to the configuration schema

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -4,6 +4,7 @@ This server can be configured using `workspace/didChangeConfiguration` method. E
 | **Configuration Key** | **Type** | **Description** | **Default** 
 |----|----|----|----|
 | `pylsp.configurationSources` | `array` of unique `string` (one of: `pycodestyle`, `pyflakes`) items | List of configuration sources to use. | `["pycodestyle"]` |
+| `pylsp.plugins.autopep8.enabled` | `boolean` | Enable or disable the plugin (disabling required to use `yapf`). | `true` |
 | `pylsp.plugins.flake8.config` | `string` | Path to the config file that will be the authoritative config source. | `null` |
 | `pylsp.plugins.flake8.enabled` | `boolean` | Enable or disable the plugin. | `false` |
 | `pylsp.plugins.flake8.exclude` | `array` of `string` items | List of files or directories to exclude. | `[]` |

--- a/pylsp/config/schema.json
+++ b/pylsp/config/schema.json
@@ -14,6 +14,11 @@
       },
       "uniqueItems": true
     },
+    "pylsp.plugins.autopep8.enabled": {
+      "type": "boolean",
+      "default": true,
+      "description": "Enable or disable the plugin (disabling required to use `yapf`)."
+    },
     "pylsp.plugins.flake8.config": {
       "type": ["string", "null"],
       "default": null,


### PR DESCRIPTION
Added a note that in order to enable yapf, one must disable autopep8.

Confirmed with the following config, which reports to the log which
formatter is being used when invoking
`<cmd>lua vim.lsp.buf.formatting()<CR>`

```
nvim_lsp.pylsp.setup {
  cmd = { "/.../bin/pylsp", "-v", "--log-file=/tmp/pylsp.log" },
  settings = {
    pylsp = {
      plugins = {
        autopep8 = {enabled = false},
      },
    },
  },
}
```

I only noticed this because my yapf config uses 2-space indenting
(thanks, Google, for forcing me to do this), and with no configuration
changes autopep8 will ignore that config in my `setup.cfg` and indent
with 4 spaces.