### PR TITLE
Improve schema type compliance, improve CONFIGURATION.md

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -3,19 +3,19 @@ This server can be configured using `workspace/didChangeConfiguration` method. E
 
 | **Configuration Key** | **Type** | **Description** | **Default** 
 |----|----|----|----|
-| `pylsp.configurationSources` | `array`  of unique `string` items | List of configuration sources to use. | `["pycodestyle"]` |
+| `pylsp.configurationSources` | `array` of unique `string` (one of: `pycodestyle`, `pyflakes`) items | List of configuration sources to use. | `["pycodestyle"]` |
 | `pylsp.plugins.flake8.config` | `string` | Path to the config file that will be the authoritative config source. | `null` |
 | `pylsp.plugins.flake8.enabled` | `boolean` | Enable or disable the plugin. | `false` |
-| `pylsp.plugins.flake8.exclude` | `array`  | List of files or directories to exclude. | `null` |
+| `pylsp.plugins.flake8.exclude` | `array` of `string` items | List of files or directories to exclude. | `[]` |
 | `pylsp.plugins.flake8.executable` | `string` | Path to the flake8 executable. | `"flake8"` |
 | `pylsp.plugins.flake8.filename` | `string` | Only check for filenames matching the patterns in this list. | `null` |
 | `pylsp.plugins.flake8.hangClosing` | `boolean` | Hang closing bracket instead of matching indentation of opening bracket's line. | `null` |
-| `pylsp.plugins.flake8.ignore` | `array`  | List of errors and warnings to ignore (or skip). | `null` |
+| `pylsp.plugins.flake8.ignore` | `array` of `string` items | List of errors and warnings to ignore (or skip). | `[]` |
 | `pylsp.plugins.flake8.maxLineLength` | `integer` | Maximum allowed line length for the entirety of this run. | `null` |
 | `pylsp.plugins.flake8.indentSize` | `integer` | Set indentation spaces. | `null` |
-| `pylsp.plugins.flake8.perFileIgnores` | `array`  | A pairing of filenames and violation codes that defines which violations to ignore in a particular file, for example: `["file_path.py:W305,W304"]`). | `null` |
-| `pylsp.plugins.flake8.select` | `array`  | List of errors and warnings to enable. | `null` |
-| `pylsp.plugins.jedi.extra_paths` | `array`  | Define extra paths for jedi.Script. | `[]` |
+| `pylsp.plugins.flake8.perFileIgnores` | `array` of `string` items | A pairing of filenames and violation codes that defines which violations to ignore in a particular file, for example: `["file_path.py:W305,W304"]`). | `[]` |
+| `pylsp.plugins.flake8.select` | `array` of unique `string` items | List of errors and warnings to enable. | `null` |
+| `pylsp.plugins.jedi.extra_paths` | `array` of `string` items | Define extra paths for jedi.Script. | `[]` |
 | `pylsp.plugins.jedi.env_vars` | `object` | Define environment variables for jedi.Script and Jedi.names. | `null` |
 | `pylsp.plugins.jedi.environment` | `string` | Define environment for jedi.Script and Jedi.names. | `null` |
 | `pylsp.plugins.jedi_completion.enabled` | `boolean` | Enable or disable the plugin. | `true` |
@@ -24,7 +24,7 @@ This server can be configured using `workspace/didChangeConfiguration` method. E
 | `pylsp.plugins.jedi_completion.fuzzy` | `boolean` | Enable fuzzy when requesting autocomplete. | `false` |
 | `pylsp.plugins.jedi_completion.eager` | `boolean` | Resolve documentation and detail eagerly. | `false` |
 | `pylsp.plugins.jedi_completion.resolve_at_most` | `number`  | How many labels and snippets (at most) should be resolved? | `25` |
-| `pylsp.plugins.jedi_completion.cache_for` | `array`  of  `string` items | Modules for which labels and snippets should be cached. | `["pandas", "numpy", "tensorflow", "matplotlib"]` |
+| `pylsp.plugins.jedi_completion.cache_for` | `array` of `string` items | Modules for which labels and snippets should be cached. | `["pandas", "numpy", "tensorflow", "matplotlib"]` |
 | `pylsp.plugins.jedi_definition.enabled` | `boolean` | Enable or disable the plugin. | `true` |
 | `pylsp.plugins.jedi_definition.follow_imports` | `boolean` | The goto call will follow imports. | `true` |
 | `pylsp.plugins.jedi_definition.follow_builtin_imports` | `boolean` | If follow_imports is True will decide if it follow builtin imports. | `true` |
@@ -37,31 +37,31 @@ This server can be configured using `workspace/didChangeConfiguration` method. E
 | `pylsp.plugins.mccabe.enabled` | `boolean` | Enable or disable the plugin. | `true` |
 | `pylsp.plugins.mccabe.threshold` | `number`  | The minimum threshold that triggers warnings about cyclomatic complexity. | `15` |
 | `pylsp.plugins.preload.enabled` | `boolean` | Enable or disable the plugin. | `true` |
-| `pylsp.plugins.preload.modules` | `array`  of unique `string` items | List of modules to import on startup | `null` |
+| `pylsp.plugins.preload.modules` | `array` of unique `string` items | List of modules to import on startup | `[]` |
 | `pylsp.plugins.pycodestyle.enabled` | `boolean` | Enable or disable the plugin. | `true` |
-| `pylsp.plugins.pycodestyle.exclude` | `array`  of unique `string` items | Exclude files or directories which match these patterns. | `null` |
-| `pylsp.plugins.pycodestyle.filename` | `array`  of unique `string` items | When parsing directories, only check filenames matching these patterns. | `null` |
-| `pylsp.plugins.pycodestyle.select` | `array`  of unique `string` items | Select errors and warnings | `null` |
-| `pylsp.plugins.pycodestyle.ignore` | `array`  of unique `string` items | Ignore errors and warnings | `null` |
+| `pylsp.plugins.pycodestyle.exclude` | `array` of unique `string` items | Exclude files or directories which match these patterns. | `[]` |
+| `pylsp.plugins.pycodestyle.filename` | `array` of unique `string` items | When parsing directories, only check filenames matching these patterns. | `[]` |
+| `pylsp.plugins.pycodestyle.select` | `array` of unique `string` items | Select errors and warnings | `[]` |
+| `pylsp.plugins.pycodestyle.ignore` | `array` of unique `string` items | Ignore errors and warnings | `[]` |
 | `pylsp.plugins.pycodestyle.hangClosing` | `boolean` | Hang closing bracket instead of matching indentation of opening bracket's line. | `null` |
 | `pylsp.plugins.pycodestyle.maxLineLength` | `number`  | Set maximum allowed line length. | `null` |
 | `pylsp.plugins.pycodestyle.indentSize` | `integer` | Set indentation spaces. | `null` |
 | `pylsp.plugins.pydocstyle.enabled` | `boolean` | Enable or disable the plugin. | `false` |
-| `pylsp.plugins.pydocstyle.convention` | `string` | Choose the basic list of checked errors by specifying an existing convention. | `null` |
-| `pylsp.plugins.pydocstyle.addIgnore` | `array`  of unique `string` items | Ignore errors and warnings in addition to the specified convention. | `null` |
-| `pylsp.plugins.pydocstyle.addSelect` | `array`  of unique `string` items | Select errors and warnings in addition to the specified convention. | `null` |
-| `pylsp.plugins.pydocstyle.ignore` | `array`  of unique `string` items | Ignore errors and warnings | `null` |
-| `pylsp.plugins.pydocstyle.select` | `array`  of unique `string` items | Select errors and warnings | `null` |
+| `pylsp.plugins.pydocstyle.convention` | `string` (one of: `pep257`, `numpy`, `None`) | Choose the basic list of checked errors by specifying an existing convention. | `null` |
+| `pylsp.plugins.pydocstyle.addIgnore` | `array` of unique `string` items | Ignore errors and warnings in addition to the specified convention. | `[]` |
+| `pylsp.plugins.pydocstyle.addSelect` | `array` of unique `string` items | Select errors and warnings in addition to the specified convention. | `[]` |
+| `pylsp.plugins.pydocstyle.ignore` | `array` of unique `string` items | Ignore errors and warnings | `[]` |
+| `pylsp.plugins.pydocstyle.select` | `array` of unique `string` items | Select errors and warnings | `[]` |
 | `pylsp.plugins.pydocstyle.match` | `string` | Check only files that exactly match the given regular expression; default is to match files that don't start with 'test_' but end with '.py'. | `"(?!test_).*\\.py"` |
 | `pylsp.plugins.pydocstyle.matchDir` | `string` | Search only dirs that exactly match the given regular expression; default is to match dirs which do not begin with a dot. | `"[^\\.].*"` |
 | `pylsp.plugins.pyflakes.enabled` | `boolean` | Enable or disable the plugin. | `true` |
 | `pylsp.plugins.pylint.enabled` | `boolean` | Enable or disable the plugin. | `false` |
-| `pylsp.plugins.pylint.args` | `array`  of non-unique `string` items | Arguments to pass to pylint. | `null` |
+| `pylsp.plugins.pylint.args` | `array` of non-unique `string` items | Arguments to pass to pylint. | `[]` |
 | `pylsp.plugins.pylint.executable` | `string` | Executable to run pylint with. Enabling this will run pylint on unsaved files via stdin. Can slow down workflow. Only works with python3. | `null` |
 | `pylsp.plugins.rope_completion.enabled` | `boolean` | Enable or disable the plugin. | `false` |
 | `pylsp.plugins.rope_completion.eager` | `boolean` | Resolve documentation and detail eagerly. | `false` |
 | `pylsp.plugins.yapf.enabled` | `boolean` | Enable or disable the plugin. | `true` |
 | `pylsp.rope.extensionModules` | `string` | Builtin and c-extension modules that are allowed to be imported and inspected by rope. | `null` |
-| `pylsp.rope.ropeFolder` | `array`  of unique `string` items | The name of the folder in which rope stores project configurations and data.  Pass `null` for not using such a folder at all. | `null` |
+| `pylsp.rope.ropeFolder` | `array` of unique `string` items | The name of the folder in which rope stores project configurations and data.  Pass `null` for not using such a folder at all. | `null` |
 
 This documentation was generated from `pylsp/config/schema.json`. Please do not edit this file directly.

--- a/pylsp/config/schema.json
+++ b/pylsp/config/schema.json
@@ -15,7 +15,7 @@
       "uniqueItems": true
     },
     "pylsp.plugins.flake8.config": {
-      "type": "string",
+      "type": ["string", "null"],
       "default": null,
       "description": "Path to the config file that will be the authoritative config source."
     },
@@ -26,7 +26,10 @@
     },
     "pylsp.plugins.flake8.exclude": {
       "type": "array",
-      "default": null,
+      "default": [],
+      "items": {
+        "type": "string"
+      },
       "description": "List of files or directories to exclude."
     },
     "pylsp.plugins.flake8.executable": {
@@ -35,52 +38,65 @@
       "description": "Path to the flake8 executable."
     },
     "pylsp.plugins.flake8.filename": {
-      "type": "string",
+      "type": ["string", "null"],
       "default": null,
       "description": "Only check for filenames matching the patterns in this list."
     },
     "pylsp.plugins.flake8.hangClosing": {
-      "type": "boolean",
+      "type": ["boolean", "null"],
       "default": null,
       "description": "Hang closing bracket instead of matching indentation of opening bracket's line."
     },
     "pylsp.plugins.flake8.ignore": {
       "type": "array",
-      "default": null,
+      "default": [],
+      "items": {
+        "type": "string"
+      },
       "description": "List of errors and warnings to ignore (or skip)."
     },
     "pylsp.plugins.flake8.maxLineLength": {
-      "type": "integer",
+      "type": ["integer", "null"],
       "default": null,
       "description": "Maximum allowed line length for the entirety of this run."
     },
     "pylsp.plugins.flake8.indentSize": {
-      "type": "integer",
+      "type": ["integer", "null"],
       "default": null,
       "description": "Set indentation spaces."
     },
     "pylsp.plugins.flake8.perFileIgnores": {
-      "type": "array",
-      "default": null,
+      "type": ["array"],
+      "default": [],
+      "items": {
+        "type": "string"
+      },
       "description": "A pairing of filenames and violation codes that defines which violations to ignore in a particular file, for example: `[\"file_path.py:W305,W304\"]`)."
     },
     "pylsp.plugins.flake8.select": {
-      "type": "array",
+      "type": ["array", "null"],
       "default": null,
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true,
       "description": "List of errors and warnings to enable."
     },
     "pylsp.plugins.jedi.extra_paths": {
       "type": "array",
       "default": [],
+      "items": {
+        "type": "string"
+      },
       "description": "Define extra paths for jedi.Script."
     },
     "pylsp.plugins.jedi.env_vars": {
-      "type": "object",
+      "type": ["object", "null"],
       "default": null,
       "description": "Define environment variables for jedi.Script and Jedi.names."
     },
     "pylsp.plugins.jedi.environment": {
-      "type": "string",
+      "type": ["string", "null"],
       "default": null,
       "description": "Define environment for jedi.Script and Jedi.names."
     },
@@ -184,7 +200,7 @@
     },
     "pylsp.plugins.preload.modules": {
       "type": "array",
-      "default": null,
+      "default": [],
       "items": {
         "type": "string"
       },
@@ -198,7 +214,7 @@
     },
     "pylsp.plugins.pycodestyle.exclude": {
       "type": "array",
-      "default": null,
+      "default": [],
       "items": {
         "type": "string"
       },
@@ -207,7 +223,7 @@
     },
     "pylsp.plugins.pycodestyle.filename": {
       "type": "array",
-      "default": null,
+      "default": [],
       "items": {
         "type": "string"
       },
@@ -216,7 +232,7 @@
     },
     "pylsp.plugins.pycodestyle.select": {
       "type": "array",
-      "default": null,
+      "default": [],
       "items": {
         "type": "string"
       },
@@ -225,7 +241,7 @@
     },
     "pylsp.plugins.pycodestyle.ignore": {
       "type": "array",
-      "default": null,
+      "default": [],
       "items": {
         "type": "string"
       },
@@ -233,17 +249,17 @@
       "description": "Ignore errors and warnings"
     },
     "pylsp.plugins.pycodestyle.hangClosing": {
-      "type": "boolean",
+      "type": ["boolean", "null"],
       "default": null,
       "description": "Hang closing bracket instead of matching indentation of opening bracket's line."
     },
     "pylsp.plugins.pycodestyle.maxLineLength": {
-      "type": "number",
+      "type": ["number", "null"],
       "default": null,
       "description": "Set maximum allowed line length."
     },
     "pylsp.plugins.pycodestyle.indentSize": {
-      "type": "integer",
+      "type": ["integer", "null"],
       "default": null,
       "description": "Set indentation spaces."
     },
@@ -253,17 +269,14 @@
       "description": "Enable or disable the plugin."
     },
     "pylsp.plugins.pydocstyle.convention": {
-      "type": "string",
+      "type": ["string", "null"],
       "default": null,
-      "enum": [
-        "pep257",
-        "numpy"
-      ],
+      "enum": ["pep257", "numpy", null],
       "description": "Choose the basic list of checked errors by specifying an existing convention."
     },
     "pylsp.plugins.pydocstyle.addIgnore": {
       "type": "array",
-      "default": null,
+      "default": [],
       "items": {
         "type": "string"
       },
@@ -272,7 +285,7 @@
     },
     "pylsp.plugins.pydocstyle.addSelect": {
       "type": "array",
-      "default": null,
+      "default": [],
       "items": {
         "type": "string"
       },
@@ -281,7 +294,7 @@
     },
     "pylsp.plugins.pydocstyle.ignore": {
       "type": "array",
-      "default": null,
+      "default": [],
       "items": {
         "type": "string"
       },
@@ -290,7 +303,7 @@
     },
     "pylsp.plugins.pydocstyle.select": {
       "type": "array",
-      "default": null,
+      "default": [],
       "items": {
         "type": "string"
       },
@@ -319,7 +332,7 @@
     },
     "pylsp.plugins.pylint.args": {
       "type": "array",
-      "default": null,
+      "default": [],
       "items": {
         "type": "string"
       },
@@ -327,7 +340,7 @@
       "description": "Arguments to pass to pylint."
     },
     "pylsp.plugins.pylint.executable": {
-      "type": "string",
+      "type": ["string", "null"],
       "default": null,
       "description": "Executable to run pylint with. Enabling this will run pylint on unsaved files via stdin. Can slow down workflow. Only works with python3."
     },
@@ -347,12 +360,12 @@
       "description": "Enable or disable the plugin."
     },
     "pylsp.rope.extensionModules": {
-      "type": "string",
+      "type": ["null", "string"],
       "default": null,
       "description": "Builtin and c-extension modules that are allowed to be imported and inspected by rope."
     },
     "pylsp.rope.ropeFolder": {
-      "type": "array",
+      "type": ["null", "array"],
       "default": null,
       "items": {
         "type": "string"


### PR DESCRIPTION
- Adds "item" to "array" types where missing
- Adds "null" type where default `null` is used
- Replace `null` with empty array (`[]`) where it made more sense (i.e. exclusion lists which are checked for truthiness rather than being `None` in the codebase)
- Improve script generating `CONFIGURATION.md`:
  - support arrays of types
  - fix double whitespace instead of single whitespace when combining strings
  - fix missing enumeration of accepted values