### PR TITLE
Use Numpy less than 1.23 in our tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ test = [
     "pytest",
     "pytest-cov",
     "coverage",
-    "numpy",
+    "numpy<1.23",
     "pandas",
     "matplotlib",
     "pyqt5",


### PR DESCRIPTION
That's because they are failing with that version (don't know why).