### PR TITLE
Fix documentation for location of Flake8 configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Like all language servers, configuration can be passed from the client that talk
 `python-lsp-server` depends on other tools, like flake8 and pycodestyle. These tools can be configured via settings passed from the client (as above), or alternatively from other configuration sources. The following sources are available:
 
 - `pycodestyle`: discovered in `~/.config/pycodestyle`, `setup.cfg`, `tox.ini` and `pycodestyle.cfg`.
-- `flake8`: discovered in `~/.config/flake8`, `setup.cfg`, `tox.ini` and `flake8.cfg`
+- `flake8`: discovered in `~/.config/flake8`, `.flake8`, `setup.cfg` and `tox.ini`
 
 The default configuration sources are `pycodestyle` and `pyflakes`. If you would like to use `flake8`, you will need to:
 


### PR DESCRIPTION
Closes python-lsp/python-lsp-server#219