### PR TITLE
Report Flake8 errors with Error severity level

### DIFF
--- a/pylsp/plugins/flake8_lint.py
+++ b/pylsp/plugins/flake8_lint.py
@@ -174,7 +174,7 @@ def parse_stdout(document, stdout):
         # show also the code in message
         msg = code + ' ' + msg
         severity = lsp.DiagnosticSeverity.Warning
-        if code[0] == "E":
+        if code == "E999" or code[0] == "F":
             severity = lsp.DiagnosticSeverity.Error
         diagnostics.append(
             {

--- a/test/plugins/test_flake8_lint.py
+++ b/test/plugins/test_flake8_lint.py
@@ -39,7 +39,7 @@ def test_flake8_unsaved(workspace):
     assert unused_var['code'] == 'F841'
     assert unused_var['range']['start'] == {'line': 5, 'character': 1}
     assert unused_var['range']['end'] == {'line': 5, 'character': 11}
-    assert unused_var['severity'] == lsp.DiagnosticSeverity.Warning
+    assert unused_var['severity'] == lsp.DiagnosticSeverity.Error
 
 
 def test_flake8_lint(workspace):
@@ -53,7 +53,7 @@ def test_flake8_lint(workspace):
         assert unused_var['code'] == 'F841'
         assert unused_var['range']['start'] == {'line': 5, 'character': 1}
         assert unused_var['range']['end'] == {'line': 5, 'character': 11}
-        assert unused_var['severity'] == lsp.DiagnosticSeverity.Warning
+        assert unused_var['severity'] == lsp.DiagnosticSeverity.Error
     finally:
         os.remove(name)
 


### PR DESCRIPTION
Error codes from Flake8 :
  - Fxxx : checks from PyFlakes => Error severity level
  - E999 : code for invalid AST => Error severity level
  - Exxx : checks from pydocstyle (syntax checks for PEP-8) => Warning severity level
  - Wxxx : checks from pydocstyle (syntax checks for PEP-8) => Warning severity level

Fixes #230
Fix PR https://github.com/python-lsp/python-lsp-server/pull/223