### PR TITLE
Remove redundant wheel dep from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Copyright 2021- Python Language Server Contributors.
 
 [build-system]
-requires = ["setuptools>=61.2.0", "wheel", "setuptools_scm[toml]>=3.4.3"]
+requires = ["setuptools>=61.2.0", "setuptools_scm[toml]>=3.4.3"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Remove the redundant `wheel` dependency, as it is added by the backend
automatically.  Listing it explicitly in the documentation was
a historical mistake and has been fixed since, see:
https://github.com/pypa/setuptools/commit/f7d30a9529378cf69054b5176249e5457aaf640a