### PR TITLE
Include traceback when plugin fails to load

### DIFF
--- a/pylsp/config/config.py
+++ b/pylsp/config/config.py
@@ -32,7 +32,7 @@ class PluginManager(pluggy.PluginManager):
         try:
             return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
         except Exception as e:  # pylint: disable=broad-except
-            log.warning(f"Failed to load hook {hook_name}: {e}")
+            log.warning(f"Failed to load hook {hook_name}: {e}", exc_info=True)
             return []
 
 


### PR DESCRIPTION
This helped me track down https://github.com/google/yapf/issues/983#issuecomment-1207283111, and it seems like it should be the default behavior when logging is enabled.