### PR TITLE
Add support for flake8 version 5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,22 +27,22 @@ Homepage = "https://github.com/python-lsp/python-lsp-server"
 [project.optional-dependencies]
 all = [
     "autopep8>=1.6.0,<1.7.0",
-    "flake8>=4.0.0,<4.1.0",
-    "mccabe>=0.6.0,<0.7.0",
-    "pycodestyle>=2.8.0,<2.9.0",
+    "flake8>=5.0.0,<5.1.0",
+    "mccabe>=0.7.0,<0.8.0",
+    "pycodestyle>=2.9.0,<2.10.0",
     "pydocstyle>=2.0.0",
-    "pyflakes>=2.4.0,<2.5.0",
+    "pyflakes>=2.5.0,<2.6.0",
     "pylint>=2.5.0",
     "rope>=0.10.5",
     "yapf",
     "whatthepatch"
 ]
 autopep8 = ["autopep8>=1.6.0,<1.7.0"]
-flake8 = ["flake8>=4.0.0,<4.1.0"]
-mccabe = ["mccabe>=0.6.0,<0.7.0"]
-pycodestyle = ["pycodestyle>=2.8.0,<2.9.0"]
+flake8 = ["flake8>=5.0.0,<5.1.0"]
+mccabe = ["mccabe>=0.7.0,<0.8.0"]
+pycodestyle = ["pycodestyle>=2.9.0,<2.10.0"]
 pydocstyle = ["pydocstyle>=2.0.0"]
-pyflakes = ["pyflakes>=2.4.0,<2.5.0"]
+pyflakes = ["pyflakes>=2.5.0,<2.6.0"]
 pylint = ["pylint>=2.5.0"]
 rope = ["rope>0.10.5"]
 yapf = ["yapf", "whatthepatch>=1.0.2,<2.0.0"]


### PR DESCRIPTION
flake8 v5 has been released a while ago and bumps its dependencies.

Appeases #232, cc @mgorny 