### PR TITLE
Fix pylint message in tests

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,13 +1,9 @@
 # Copyright 2017-2020 Palantir Technologies, Inc.
 # Copyright 2021- Python Language Server Contributors.
 
-import sys
 import pytest
 from pylsp import IS_WIN
 
-IS_PY3 = sys.version_info.major == 3
 
 unix_only = pytest.mark.skipif(IS_WIN, reason="Unix only")
 windows_only = pytest.mark.skipif(not IS_WIN, reason="Windows only")
-py3_only = pytest.mark.skipif(not IS_PY3, reason="Python3 only")
-py2_only = pytest.mark.skipif(IS_PY3, reason="Python2 only")

--- a/test/plugins/test_pylint_lint.py
+++ b/test/plugins/test_pylint_lint.py
@@ -4,7 +4,6 @@
 
 import contextlib
 import os
-import sys
 import tempfile
 
 from pylsp import lsp, uris
@@ -70,10 +69,8 @@ def test_syntax_error_pylint(config, workspace):
     with temp_document(DOC_SYNTAX_ERR, workspace) as doc:
         diag = pylint_lint.pylsp_lint(config, doc, True)[0]
 
-        if sys.version_info[:2] >= (3, 10):
-            assert diag['message'].count("[syntax-error] expected ':'")
-        else:
-            assert diag['message'].startswith('[syntax-error] invalid syntax')
+        assert diag['message'].startswith("[syntax-error]")
+        assert diag['message'].count("expected ':'") or diag['message'].count('invalid syntax')
         # Pylint doesn't give column numbers for invalid syntax.
         assert diag['range']['start'] == {'line': 0, 'character': 12}
         assert diag['severity'] == lsp.DiagnosticSeverity.Error
@@ -83,7 +80,7 @@ def test_syntax_error_pylint(config, workspace):
         config.plugin_settings('pylint')['executable'] = 'pylint'
         diag = pylint_lint.pylsp_lint(config, doc, True)[0]
 
-        assert diag['message'].count("expected ':'") or diag['message'].startswith('invalid syntax')
+        assert diag['message'].count("expected ':'") or diag['message'].count('invalid syntax')
         # Pylint doesn't give column numbers for invalid syntax.
         assert diag['range']['start'] == {'line': 0, 'character': 12}
         assert diag['severity'] == lsp.DiagnosticSeverity.Error

--- a/test/plugins/test_pylint_lint.py
+++ b/test/plugins/test_pylint_lint.py
@@ -7,7 +7,6 @@ import os
 import sys
 import tempfile
 
-from test import py2_only, py3_only, IS_PY3
 from pylsp import lsp, uris
 from pylsp.workspace import Document
 from pylsp.plugins import pylint_lint
@@ -53,23 +52,21 @@ def test_pylint(config, workspace):
         assert unused_import['severity'] == lsp.DiagnosticSeverity.Warning
         assert unused_import['tags'] == [lsp.DiagnosticTag.Unnecessary]
 
-        if IS_PY3:
-            # test running pylint in stdin
-            config.plugin_settings('pylint')['executable'] = 'pylint'
-            diags = pylint_lint.pylsp_lint(config, doc, True)
+        # test running pylint in stdin
+        config.plugin_settings('pylint')['executable'] = 'pylint'
+        diags = pylint_lint.pylsp_lint(config, doc, True)
 
-            msg = 'Unused import sys (unused-import)'
-            unused_import = [d for d in diags if d['message'] == msg][0]
+        msg = 'Unused import sys (unused-import)'
+        unused_import = [d for d in diags if d['message'] == msg][0]
 
-            assert unused_import['range']['start'] == {
-                'line': 0,
-                'character': 0,
-            }
-            assert unused_import['severity'] == lsp.DiagnosticSeverity.Warning
+        assert unused_import['range']['start'] == {
+            'line': 0,
+            'character': 0,
+        }
+        assert unused_import['severity'] == lsp.DiagnosticSeverity.Warning
 
 
-@py3_only
-def test_syntax_error_pylint_py3(config, workspace):
+def test_syntax_error_pylint(config, workspace):
     with temp_document(DOC_SYNTAX_ERR, workspace) as doc:
         diag = pylint_lint.pylsp_lint(config, doc, True)[0]
 
@@ -89,17 +86,6 @@ def test_syntax_error_pylint_py3(config, workspace):
         assert diag['message'].count("expected ':'") or diag['message'].startswith('invalid syntax')
         # Pylint doesn't give column numbers for invalid syntax.
         assert diag['range']['start'] == {'line': 0, 'character': 12}
-        assert diag['severity'] == lsp.DiagnosticSeverity.Error
-
-
-@py2_only
-def test_syntax_error_pylint_py2(config, workspace):
-    with temp_document(DOC_SYNTAX_ERR, workspace) as doc:
-        diag = pylint_lint.pylsp_lint(config, doc, True)[0]
-
-        assert diag['message'].startswith('[syntax-error] invalid syntax')
-        # Pylint doesn't give column numbers for invalid syntax.
-        assert diag['range']['start'] == {'line': 0, 'character': 0}
         assert diag['severity'] == lsp.DiagnosticSeverity.Error
 
 


### PR DESCRIPTION
Fixes the failures first seen in #257 due to a changed message format in pylint (possibly 2.15.0 as the last runs on develop with 2.14.4 and 2.15.5 in # 250 were fine)

Also removes old unused Python 2 code