### PR TITLE
Fix options not being passed to yapf format

### DIFF
--- a/pylsp/plugins/autopep8_format.py
+++ b/pylsp/plugins/autopep8_format.py
@@ -13,13 +13,13 @@ log = logging.getLogger(__name__)
 
 
 @hookimpl(tryfirst=True)  # Prefer autopep8 over YAPF
-def pylsp_format_document(config, document, options=None):  # pylint: disable=unused-argument
+def pylsp_format_document(config, document, options):  # pylint: disable=unused-argument
     log.info("Formatting document %s with autopep8", document)
     return _format(config, document)
 
 
 @hookimpl(tryfirst=True)  # Prefer autopep8 over YAPF
-def pylsp_format_range(config, document, range, options=None):  # pylint: disable=redefined-builtin,unused-argument
+def pylsp_format_range(config, document, range, options):  # pylint: disable=redefined-builtin,unused-argument
     log.info("Formatting document %s in range %s with autopep8", document, range)
 
     # First we 'round' the range up/down to full lines only

--- a/pylsp/plugins/yapf_format.py
+++ b/pylsp/plugins/yapf_format.py
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
 
 
 @hookimpl
-def pylsp_format_document(document, options=None):
+def pylsp_format_document(document, options):
     return _format(document, options=options)
 
 

--- a/pylsp/plugins/yapf_format.py
+++ b/pylsp/plugins/yapf_format.py
@@ -21,7 +21,7 @@ def pylsp_format_document(document, options):
 
 
 @hookimpl
-def pylsp_format_range(document, range, options=None):  # pylint: disable=redefined-builtin
+def pylsp_format_range(document, range, options):  # pylint: disable=redefined-builtin
     # First we 'round' the range up/down to full lines only
     range['start']['character'] = 0
     range['end']['line'] += 1

--- a/test/plugins/test_autopep8_format.py
+++ b/test/plugins/test_autopep8_format.py
@@ -41,7 +41,7 @@ bar = {'foo': foo
 
 def test_format(config, workspace):
     doc = Document(DOC_URI, workspace, DOC)
-    res = pylsp_format_document(config, doc)
+    res = pylsp_format_document(config, doc, options=None)
 
     assert len(res) == 1
     assert res[0]['newText'] == "a = 123\n\n\ndef func():\n    pass\n"
@@ -64,12 +64,12 @@ def test_range_format(config, workspace):
 
 def test_no_change(config, workspace):
     doc = Document(DOC_URI, workspace, GOOD_DOC)
-    assert not pylsp_format_document(config, doc)
+    assert not pylsp_format_document(config, doc, options=None)
 
 
 def test_hanging_indentation(config, workspace):
     doc = Document(DOC_URI, workspace, INDENTED_DOC)
-    res = pylsp_format_document(config, doc)
+    res = pylsp_format_document(config, doc, options=None)
 
     assert len(res) == 1
     assert res[0]['newText'] == CORRECT_INDENTED_DOC
@@ -78,6 +78,6 @@ def test_hanging_indentation(config, workspace):
 @pytest.mark.parametrize('newline', ['\r\n', '\r'])
 def test_line_endings(config, workspace, newline):
     doc = Document(DOC_URI, workspace, f'import os;import sys{2 * newline}dict(a=1)')
-    res = pylsp_format_document(config, doc)
+    res = pylsp_format_document(config, doc, options=None)
 
     assert res[0]['newText'] == f'import os{newline}import sys{2 * newline}dict(a=1){newline}'

--- a/test/plugins/test_autopep8_format.py
+++ b/test/plugins/test_autopep8_format.py
@@ -54,7 +54,7 @@ def test_range_format(config, workspace):
         'start': {'line': 0, 'character': 0},
         'end': {'line': 2, 'character': 0}
     }
-    res = pylsp_format_range(config, doc, def_range)
+    res = pylsp_format_range(config, doc, def_range, options=None)
 
     assert len(res) == 1
 

--- a/test/plugins/test_yapf_format.py
+++ b/test/plugins/test_yapf_format.py
@@ -49,7 +49,7 @@ def test_range_format(workspace):
 
 def test_no_change(workspace):
     doc = Document(DOC_URI, workspace, GOOD_DOC)
-    assert not pylsp_format_document(doc)
+    assert not pylsp_format_document(doc, options=None)
 
 
 def test_config_file(tmpdir, workspace):
@@ -59,7 +59,7 @@ def test_config_file(tmpdir, workspace):
     src = tmpdir.join('test.py')
     doc = Document(uris.from_fs_path(src.strpath), workspace, DOC)
 
-    res = pylsp_format_document(doc)
+    res = pylsp_format_document(doc, options=None)
 
     # A was split on multiple lines because of column_limit from config file
     assert apply_text_edits(doc, res) == "A = [\n    'h', 'w',\n    'a'\n]\n\nB = ['h', 'w']\n"
@@ -68,7 +68,7 @@ def test_config_file(tmpdir, workspace):
 @pytest.mark.parametrize('newline', ['\r\n'])
 def test_line_endings(workspace, newline):
     doc = Document(DOC_URI, workspace, f'import os;import sys{2 * newline}dict(a=1)')
-    res = pylsp_format_document(doc)
+    res = pylsp_format_document(doc, options=None)
 
     assert apply_text_edits(doc, res) == f'import os{newline}import sys{2 * newline}dict(a=1){newline}'
 
@@ -99,7 +99,7 @@ def test_format_returns_text_edit_per_line(workspace):
  log("x")
  log("hi")"""
     doc = Document(DOC_URI, workspace, single_space_indent)
-    res = pylsp_format_document(doc)
+    res = pylsp_format_document(doc, options=None)
 
     # two removes and two adds
     assert len(res) == 4

--- a/test/plugins/test_yapf_format.py
+++ b/test/plugins/test_yapf_format.py
@@ -29,7 +29,7 @@ FOUR_SPACE_DOC = """def hello():
 
 def test_format(workspace):
     doc = Document(DOC_URI, workspace, DOC)
-    res = pylsp_format_document(doc)
+    res = pylsp_format_document(doc, None)
 
     assert apply_text_edits(doc, res) == "A = ['h', 'w', 'a']\n\nB = ['h', 'w']\n"
 
@@ -41,7 +41,7 @@ def test_range_format(workspace):
         'start': {'line': 0, 'character': 0},
         'end': {'line': 4, 'character': 10}
     }
-    res = pylsp_format_range(doc, def_range)
+    res = pylsp_format_range(doc, def_range, None)
 
     # Make sure B is still badly formatted
     assert apply_text_edits(doc, res) == "A = ['h', 'w', 'a']\n\nB = ['h',\n\n\n'w']\n"


### PR DESCRIPTION
In #134 we added formatting options, but those don't seem to work.

I don't understand how this magical "hook" thingy works, but removing the default value from the `hookImpl` for `pylsp_format_document` fixes the issue.

Should be fine since `None` is specified here https://github.com/python-lsp/python-lsp-server/blob/develop/pylsp/python_lsp.py#L442

Are there integration tests I can add to test the whole "hook" flow?