### PR TITLE
Prefer info log message for missing optional modules

### DIFF
--- a/pylsp/config/config.py
+++ b/pylsp/config/config.py
@@ -71,7 +71,7 @@ class Config:
             try:
                 entry_point.load()
             except Exception as e:  # pylint: disable=broad-except
-                log.warning("Failed to load %s entry point '%s': %s", PYLSP, entry_point.name, e)
+                log.info("Failed to load %s entry point '%s': %s", PYLSP, entry_point.name, e)
                 self._pm.set_blocked(entry_point.name)
 
         # Load the entry points into pluggy, having blocked any failing ones


### PR DESCRIPTION
Some modules are optional and therefore may not be installed by the user.  Log such events for information rather than a warning to the user.

Resolves #265.