### PR TITLE
Update the configuration schema for consistency

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -1,9 +1,9 @@
 # Python Language Server Configuration
-This server can be configured using `workspace/didChangeConfiguration` method. Each configuration option is described below:
+This server can be configured using the `workspace/didChangeConfiguration` method. Each configuration option is described below. Note, a value of `null` means that we do not set a value and thus use the plugin's default value.
 
 | **Configuration Key** | **Type** | **Description** | **Default** 
 |----|----|----|----|
-| `pylsp.configurationSources` | `array` of unique `string` (one of: `pycodestyle`, `pyflakes`) items | List of configuration sources to use. | `["pycodestyle"]` |
+| `pylsp.configurationSources` | `array` of unique `string` (one of: `'pycodestyle'`, `'flake8'`) items | List of configuration sources to use. | `["pycodestyle"]` |
 | `pylsp.plugins.autopep8.enabled` | `boolean` | Enable or disable the plugin (disabling required to use `yapf`). | `true` |
 | `pylsp.plugins.flake8.config` | `string` | Path to the config file that will be the authoritative config source. | `null` |
 | `pylsp.plugins.flake8.enabled` | `boolean` | Enable or disable the plugin. | `false` |
@@ -25,7 +25,7 @@ This server can be configured using `workspace/didChangeConfiguration` method. E
 | `pylsp.plugins.jedi_completion.include_function_objects` | `boolean` | Adds function objects as a separate completion item. | `true` |
 | `pylsp.plugins.jedi_completion.fuzzy` | `boolean` | Enable fuzzy when requesting autocomplete. | `false` |
 | `pylsp.plugins.jedi_completion.eager` | `boolean` | Resolve documentation and detail eagerly. | `false` |
-| `pylsp.plugins.jedi_completion.resolve_at_most` | `number`  | How many labels and snippets (at most) should be resolved? | `25` |
+| `pylsp.plugins.jedi_completion.resolve_at_most` | `integer` | How many labels and snippets (at most) should be resolved? | `25` |
 | `pylsp.plugins.jedi_completion.cache_for` | `array` of `string` items | Modules for which labels and snippets should be cached. | `["pandas", "numpy", "tensorflow", "matplotlib"]` |
 | `pylsp.plugins.jedi_definition.enabled` | `boolean` | Enable or disable the plugin. | `true` |
 | `pylsp.plugins.jedi_definition.follow_imports` | `boolean` | The goto call will follow imports. | `true` |
@@ -37,23 +37,23 @@ This server can be configured using `workspace/didChangeConfiguration` method. E
 | `pylsp.plugins.jedi_symbols.all_scopes` | `boolean` | If True lists the names of all scopes instead of only the module namespace. | `true` |
 | `pylsp.plugins.jedi_symbols.include_import_symbols` | `boolean` | If True includes symbols imported from other libraries. | `true` |
 | `pylsp.plugins.mccabe.enabled` | `boolean` | Enable or disable the plugin. | `true` |
-| `pylsp.plugins.mccabe.threshold` | `number`  | The minimum threshold that triggers warnings about cyclomatic complexity. | `15` |
+| `pylsp.plugins.mccabe.threshold` | `integer` | The minimum threshold that triggers warnings about cyclomatic complexity. | `15` |
 | `pylsp.plugins.preload.enabled` | `boolean` | Enable or disable the plugin. | `true` |
 | `pylsp.plugins.preload.modules` | `array` of unique `string` items | List of modules to import on startup | `[]` |
 | `pylsp.plugins.pycodestyle.enabled` | `boolean` | Enable or disable the plugin. | `true` |
 | `pylsp.plugins.pycodestyle.exclude` | `array` of unique `string` items | Exclude files or directories which match these patterns. | `[]` |
 | `pylsp.plugins.pycodestyle.filename` | `array` of unique `string` items | When parsing directories, only check filenames matching these patterns. | `[]` |
-| `pylsp.plugins.pycodestyle.select` | `array` of unique `string` items | Select errors and warnings | `[]` |
+| `pylsp.plugins.pycodestyle.select` | `array` of unique `string` items | Select errors and warnings | `null` |
 | `pylsp.plugins.pycodestyle.ignore` | `array` of unique `string` items | Ignore errors and warnings | `[]` |
 | `pylsp.plugins.pycodestyle.hangClosing` | `boolean` | Hang closing bracket instead of matching indentation of opening bracket's line. | `null` |
-| `pylsp.plugins.pycodestyle.maxLineLength` | `number`  | Set maximum allowed line length. | `null` |
+| `pylsp.plugins.pycodestyle.maxLineLength` | `integer` | Set maximum allowed line length. | `null` |
 | `pylsp.plugins.pycodestyle.indentSize` | `integer` | Set indentation spaces. | `null` |
 | `pylsp.plugins.pydocstyle.enabled` | `boolean` | Enable or disable the plugin. | `false` |
-| `pylsp.plugins.pydocstyle.convention` | `string` (one of: `pep257`, `numpy`, `None`) | Choose the basic list of checked errors by specifying an existing convention. | `null` |
+| `pylsp.plugins.pydocstyle.convention` | `string` (one of: `'pep257'`, `'numpy'`, `None`) | Choose the basic list of checked errors by specifying an existing convention. | `null` |
 | `pylsp.plugins.pydocstyle.addIgnore` | `array` of unique `string` items | Ignore errors and warnings in addition to the specified convention. | `[]` |
 | `pylsp.plugins.pydocstyle.addSelect` | `array` of unique `string` items | Select errors and warnings in addition to the specified convention. | `[]` |
 | `pylsp.plugins.pydocstyle.ignore` | `array` of unique `string` items | Ignore errors and warnings | `[]` |
-| `pylsp.plugins.pydocstyle.select` | `array` of unique `string` items | Select errors and warnings | `[]` |
+| `pylsp.plugins.pydocstyle.select` | `array` of unique `string` items | Select errors and warnings | `null` |
 | `pylsp.plugins.pydocstyle.match` | `string` | Check only files that exactly match the given regular expression; default is to match files that don't start with 'test_' but end with '.py'. | `"(?!test_).*\\.py"` |
 | `pylsp.plugins.pydocstyle.matchDir` | `string` | Search only dirs that exactly match the given regular expression; default is to match dirs which do not begin with a dot. | `"[^\\.].*"` |
 | `pylsp.plugins.pyflakes.enabled` | `boolean` | Enable or disable the plugin. | `true` |

--- a/pylsp/config/schema.json
+++ b/pylsp/config/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Python Language Server Configuration",
-  "description": "This server can be configured using `workspace/didChangeConfiguration` method. Each configuration option is described below:",
+  "description": "This server can be configured using the `workspace/didChangeConfiguration` method. Each configuration option is described below. Note, a value of `null` means that we do not set a value and thus use the plugin's default value.",
   "type": "object",
   "properties": {
     "pylsp.configurationSources": {
@@ -10,7 +10,7 @@
       "description": "List of configuration sources to use.",
       "items": {
         "type": "string",
-        "enum": ["pycodestyle", "pyflakes"]
+        "enum": ["pycodestyle", "flake8"]
       },
       "uniqueItems": true
     },
@@ -136,7 +136,7 @@
       "description": "Resolve documentation and detail eagerly."
     },
     "pylsp.plugins.jedi_completion.resolve_at_most": {
-      "type": "number",
+      "type": "integer",
       "default": 25,
       "description": "How many labels and snippets (at most) should be resolved?"
     },
@@ -199,7 +199,7 @@
       "description": "Enable or disable the plugin."
     },
     "pylsp.plugins.mccabe.threshold": {
-      "type": "number",
+      "type": "integer",
       "default": 15,
       "description": "The minimum threshold that triggers warnings about cyclomatic complexity."
     },
@@ -241,8 +241,8 @@
       "description": "When parsing directories, only check filenames matching these patterns."
     },
     "pylsp.plugins.pycodestyle.select": {
-      "type": "array",
-      "default": [],
+      "type": ["array", "null"],
+      "default": null,
       "items": {
         "type": "string"
       },
@@ -264,7 +264,7 @@
       "description": "Hang closing bracket instead of matching indentation of opening bracket's line."
     },
     "pylsp.plugins.pycodestyle.maxLineLength": {
-      "type": ["number", "null"],
+      "type": ["integer", "null"],
       "default": null,
       "description": "Set maximum allowed line length."
     },
@@ -312,8 +312,8 @@
       "description": "Ignore errors and warnings"
     },
     "pylsp.plugins.pydocstyle.select": {
-      "type": "array",
-      "default": [],
+      "type": ["array", "null"],
+      "default": null,
       "items": {
         "type": "string"
       },
@@ -370,12 +370,12 @@
       "description": "Enable or disable the plugin."
     },
     "pylsp.rope.extensionModules": {
-      "type": ["null", "string"],
+      "type": ["string", "null"],
       "default": null,
       "description": "Builtin and c-extension modules that are allowed to be imported and inspected by rope."
     },
     "pylsp.rope.ropeFolder": {
-      "type": ["null", "array"],
+      "type": ["array", "null"],
       "default": null,
       "items": {
         "type": "string"

--- a/scripts/jsonschema2md.py
+++ b/scripts/jsonschema2md.py
@@ -41,7 +41,7 @@ def describe_type(prop: dict) -> str:
         if  option in EXTRA_DESCRIPTORS:
             parts.append(EXTRA_DESCRIPTORS[option](prop))
     if "enum" in prop:
-        allowed_values = [f"`{value}`" for value in prop["enum"]]
+        allowed_values = [f"`{value!r}`" for value in prop["enum"]]
         parts.append("(one of: " + ", ".join(allowed_values) + ")")
     return " ".join(parts)
 


### PR DESCRIPTION
- Clarify the meaning of a `null` configuration option value.
- Make CONFIGURATION.md consistent with the README.
- Apply consistency to datatypes and default values.
- Re-order specific type field array values to be consistent with others.

Resolves #263 
Resolves #264.