### PR TITLE
We forked python-lsp-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Python LSP Server
 
-[![image](https://github.com/python-ls/python-ls/workflows/Linux%20tests/badge.svg)](https://github.com/python-ls/python-ls/actions?query=workflow%3A%22Linux+tests%22) [![image](https://github.com/python-ls/python-ls/workflows/Mac%20tests/badge.svg)](https://github.com/python-ls/python-ls/actions?query=workflow%3A%22Mac+tests%22) [![image](https://github.com/python-ls/python-ls/workflows/Windows%20tests/badge.svg)](https://github.com/python-ls/python-ls/actions?query=workflow%3A%22Windows+tests%22) [![image](https://img.shields.io/github/license/python-ls/python-ls.svg)](https://github.com/python-ls/python-ls/blob/master/LICENSE)
+This is a fork of https://github.com/python-lsp/python-lsp-server.
 
 A Python 3.7+ implementation of the [Language Server Protocol](https://github.com/Microsoft/language-server-protocol).
 (Note: versions <1.4 should still work with Python 3.6)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is a fork of https://github.com/python-lsp/python-lsp-server.
 
+See [RELEASE.md] for how to make a new release.
+
 A Python 3.7+ implementation of the [Language Server Protocol](https://github.com/Microsoft/language-server-protocol).
 (Note: versions <1.4 should still work with Python 3.6)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,21 +1,11 @@
-## Before the release:
+## To release a new version of replit-python-lsp-server:
 
-1. Create pull request to update CHANGELOG.md with
-    * `loghub python-lsp/python-lsp-server -m vX.X.X`
-    * git add -A && git commit -m "Update changelog for X.X.X"
-
-    This is necessary to run our tests before the release, so we can be sure
-    everything is in order.
-## To release a new version of python-lsp-server:
-
-1. git fetch upstream && git checkout upstream/master
-2. Close milestone on GitHub
-3. git clean -xfdi
-4. git tag -a vX.X.X -m "Release vX.X.X"
-5. python -m pip install --upgrade pip
-6. pip install --upgrade --upgrade-strategy eager build setuptools twine wheel
-7. python -bb -X dev -W error -m build
-8. twine check --strict dist/*
-9. twine upload dist/*
-10. git push upstream --tags
-11. Create release on Github
+0. rm -r dist
+1. git clean -xfdi
+2. git tag -a vX.X.X -m "Release vX.X.X"
+3. python -m pip install --upgrade pip
+4. pip install --upgrade --upgrade-strategy eager build setuptools twine wheel
+5. python -bb -X dev -W error -m build
+6. twine check --strict dist/*
+7. twine upload dist/*
+8. git push upstream --tags

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "pluggy>=1.0.0",
     "ujson>=3.0.0",
     "setuptools>=39.0.0",
+    "toml=>0.10.2",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = ["setuptools>=61.2.0", "setuptools_scm[toml]>=3.4.3"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "python-lsp-server"
+name = "replit-python-lsp-server"
 authors = [{name = "Python Language Server Contributors"}]
 description = "Python Language Server for the Language Server Protocol"
 readme = "README.md"
@@ -22,7 +22,7 @@ dependencies = [
 dynamic = ["version"]
 
 [project.urls]
-Homepage = "https://github.com/python-lsp/python-lsp-server"
+Homepage = "https://github.com/replit/python-lsp-server"
 
 [project.optional-dependencies]
 all = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "pluggy>=1.0.0",
     "ujson>=3.0.0",
     "setuptools>=39.0.0",
-    "toml=>0.10.2",
+    "toml>=0.10.2"
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
# Why?

We want control of this code and the ability to make new releases because we and regularly having to maintain it.

## What Changed?

1. Updated README.md and RELEASE.md
2. Renamed library to replit-python-lsp-server in pyproject.toml
3. Added toml to the dependency list

## Test change

We've publish the @replit/Python with this updated library. Test the indent switching ability of the formatter:

1. Create python function with 2 spaces
2. Change your settings to 4 spaces (or tabs)
3. Hit format
4. Confirm formatting updates the indent and matches user options