### PR TITLE
Include params only for classes and functions

### DIFF
--- a/pylsp/plugins/jedi_completion.py
+++ b/pylsp/plugins/jedi_completion.py
@@ -73,7 +73,7 @@ def pylsp_completions(config, document, position):
         _format_completion(
             c,
             markup_kind=preferred_markup_kind,
-            include_params=include_params,
+            include_params=include_params if c.type in ["class", "function"] else False,
             resolve=resolve_eagerly,
             resolve_label_or_snippet=(i < max_to_resolve)
         )


### PR DESCRIPTION
This PR lets `include_params` take effects only for functions and classes, which avoids unnecessary parenthesis in the completion results in some cases.

All tests passed. @ccordoba12 