### PR TITLE
Make default for `include_function_objects` false

### DIFF
--- a/pylsp/plugins/jedi_completion.py
+++ b/pylsp/plugins/jedi_completion.py
@@ -57,7 +57,7 @@ def pylsp_completions(config, document, position):
 
     should_include_params = settings.get('include_params')
     should_include_class_objects = settings.get('include_class_objects', True)
-    should_include_function_objects = settings.get('include_function_objects', True)
+    should_include_function_objects = settings.get('include_function_objects', False)
 
     max_to_resolve = settings.get('resolve_at_most', 25)
     modules_to_cache_for = settings.get('cache_for', None)


### PR DESCRIPTION
Fixes https://github.com/python-lsp/python-lsp-server/issues/273. This PR makes the `include_function_objects option` False by default.