### PR TITLE
Improve how Jedi handles Numpy

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -16,6 +16,7 @@ This server can be configured using the `workspace/didChangeConfiguration` metho
 | `pylsp.plugins.flake8.indentSize` | `integer` | Set indentation spaces. | `null` |
 | `pylsp.plugins.flake8.perFileIgnores` | `array` of `string` items | A pairing of filenames and violation codes that defines which violations to ignore in a particular file, for example: `["file_path.py:W305,W304"]`). | `[]` |
 | `pylsp.plugins.flake8.select` | `array` of unique `string` items | List of errors and warnings to enable. | `null` |
+| `pylsp.plugins.jedi.auto_import_modules` | `array` of `string` items | List of module names for jedi.settings.auto_import_modules. | `["numpy"]` |
 | `pylsp.plugins.jedi.extra_paths` | `array` of `string` items | Define extra paths for jedi.Script. | `[]` |
 | `pylsp.plugins.jedi.env_vars` | `object` | Define environment variables for jedi.Script and Jedi.names. | `null` |
 | `pylsp.plugins.jedi.environment` | `string` | Define environment for jedi.Script and Jedi.names. | `null` |

--- a/pylsp/config/schema.json
+++ b/pylsp/config/schema.json
@@ -87,6 +87,14 @@
       "uniqueItems": true,
       "description": "List of errors and warnings to enable."
     },
+    "pylsp.plugins.jedi.auto_import_modules": {
+      "type": "array",
+      "default": ["numpy"],
+      "items": {
+        "type": "string"
+      },
+      "description": "List of module names for jedi.settings.auto_import_modules."
+    },
     "pylsp.plugins.jedi.extra_paths": {
       "type": "array",
       "default": [],

--- a/pylsp/workspace.py
+++ b/pylsp/workspace.py
@@ -14,6 +14,8 @@ from . import lsp, uris, _utils
 
 log = logging.getLogger(__name__)
 
+DEFAULT_AUTO_IMPORT_MODULES = ["numpy"]
+
 # TODO: this is not the best e.g. we capture numbers
 RE_START_WORD = re.compile('[A-Za-z_0-9]*$')
 RE_END_WORD = re.compile('^[A-Za-z_0-9]*')
@@ -252,6 +254,8 @@ class Document:
 
         if self._config:
             jedi_settings = self._config.plugin_settings('jedi', document_path=self.path)
+            jedi.settings.auto_import_modules = jedi_settings.get('auto_import_modules',
+                                                                  DEFAULT_AUTO_IMPORT_MODULES)
             environment_path = jedi_settings.get('environment')
             extra_paths = jedi_settings.get('extra_paths') or []
             env_vars = jedi_settings.get('env_vars')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ test = [
     "pytest",
     "pytest-cov",
     "coverage",
-    "numpy<1.23",
+    "numpy",
     "pandas",
     "matplotlib",
     "pyqt5",


### PR DESCRIPTION
The documentation of [jedi.settings.auto_import_modules](https://jedi.readthedocs.io/en/latest/docs/settings.html#dynamic-stuff) tells that jedi may handle numpy's module globals trickery better when importing numpy instead of parsing.  The example script below prints the documentation strings of one of numpy's universal functions as well as the numpy version:

``` python
#!/usr/bin/env python
import jedi, numpy

# The next setting enables jedi to find the documention string of ufuncs:
jedi.settings.auto_import_modules = ["numpy"]
# Find the documentation string of numpy.cosh by completing numpy.cos:
script = jedi.Script(code := "import numpy; numpy.cos", path="<string>")
print(script.complete(1, len(code))[1].docstring())
print(f"numpy version: {numpy.version.__version__}")
```

The pull request adds numpy to jedi's auto\_import\_modules and allows the user to modify the module list.  The patch fixes:
1. The display of those documentation strings of numpy's universal functions by Eglot and python-lsp-server is good enough for me (I am using this patch for more than a year for this reason).
2. The incompatibility of jedi/python-lsp-server with numpy-1.23.x (this is a bonus).

Fixes #243.