### PR TITLE
Autoimport PT2 (docstrings)

### DIFF
--- a/pylsp/plugins/rope_autoimport.py
+++ b/pylsp/plugins/rope_autoimport.py
@@ -1,0 +1,207 @@
+# Copyright 2022- Python Language Server Contributors.
+
+import logging
+from typing import Any, Dict, Generator, List, Set
+
+import parso
+from jedi import Script
+from parso.python import tree
+from parso.tree import NodeOrLeaf
+from rope.base.resources import Resource
+from rope.contrib.autoimport.defs import SearchResult
+from rope.contrib.autoimport.sqlite import AutoImport
+
+from pylsp import hookimpl
+from pylsp._utils import format_docstring
+from pylsp.config.config import Config
+from pylsp.workspace import Document, Workspace
+
+log = logging.getLogger(__name__)
+
+_score_pow = 5
+_score_max = 10**_score_pow
+MAX_RESULTS = 1000
+
+
+@hookimpl
+def pylsp_settings() -> Dict[str, Dict[str, Dict[str, Any]]]:
+    # Default rope_completion to disabled
+    return {"plugins": {"rope_autoimport": {"enabled": True, "memory": False}}}
+
+
+def _should_insert(expr: tree.BaseNode, word_node: tree.Leaf) -> bool:
+    """
+    Check if we should insert the word_node on the given expr.
+
+    Works for both correct and incorrect code. This is because the
+    user is often working on the code as they write it.
+    """
+    if len(expr.children) == 0:
+        return True
+    first_child = expr.children[0]
+    if isinstance(first_child, tree.EndMarker):
+        if "#" in first_child.prefix:
+            return False  # Check for single line comment
+    if first_child == word_node:
+        return True  # If the word is the first word then its fine
+    if len(expr.children) > 1:
+        if any(node.type == "operator" and "." in node.value or node.type == "trailer" for node in expr.children):
+            return False  # Check if we're on a method of a function
+    if isinstance(first_child, (tree.PythonErrorNode, tree.PythonNode)):
+        # The tree will often include error nodes like this to indicate errors
+        # we want to ignore errors since the code is being written
+        return _should_insert(first_child, word_node)
+    return _handle_first_child(first_child, expr, word_node)
+
+
+def _handle_first_child(first_child: NodeOrLeaf, expr: tree.BaseNode, word_node: tree.Leaf) -> bool:
+    """Check if we suggest imports given the following first child."""
+    if isinstance(first_child, tree.Import):
+        return False
+    if isinstance(first_child, (tree.PythonLeaf, tree.PythonErrorLeaf)):
+        # Check if the first item is a from or import statement even when incomplete
+        if first_child.value in ("import", "from"):
+            return False
+    if isinstance(first_child, tree.Keyword):
+        if first_child.value == "def":
+            return _should_import_function(word_node, expr)
+        if first_child.value == "class":
+            return _should_import_class(word_node, expr)
+    return True
+
+
+def _should_import_class(word_node: tree.Leaf, expr: tree.BaseNode) -> bool:
+    prev_node = None
+    for node in expr.children:
+        if isinstance(node, tree.Name):
+            if isinstance(prev_node, tree.Operator):
+                if node == word_node and prev_node.value == "(":
+                    return True
+        prev_node = node
+
+    return False
+
+
+def _should_import_function(word_node: tree.Leaf, expr: tree.BaseNode) -> bool:
+    prev_node = None
+    for node in expr.children:
+        if _handle_argument(node, word_node):
+            return True
+        if isinstance(prev_node, tree.Operator):
+            if prev_node.value == "->":
+                if node == word_node:
+                    return True
+        prev_node = node
+    return False
+
+
+def _handle_argument(node: NodeOrLeaf, word_node: tree.Leaf):
+    if isinstance(node, tree.PythonNode):
+        if node.type == "tfpdef":
+            if node.children[2] == word_node:
+                return True
+        if node.type == "parameters":
+            for parameter in node.children:
+                if _handle_argument(parameter, word_node):
+                    return True
+    return False
+
+
+def _process_statements(
+    suggestions: List[SearchResult],
+    doc_uri: str,
+    word: str,
+    autoimport: AutoImport,
+    document: Document,
+) -> Generator[Dict[str, Any], None, None]:
+    for suggestion in suggestions:
+        insert_line = autoimport.find_insertion_line(document.source) - 1
+        start = {"line": insert_line, "character": 0}
+        edit_range = {"start": start, "end": start}
+        edit = {"range": edit_range, "newText": suggestion.import_statement + "\n"}
+        score = _get_score(suggestion.source, suggestion.import_statement, suggestion.name, word)
+        if score > _score_max:
+            continue
+        # TODO make this markdown
+        yield {
+            "label": suggestion.name,
+            "kind": suggestion.itemkind,
+            "sortText": _sort_import(score),
+            "data": {"doc_uri": doc_uri},
+            "detail": _document(suggestion.import_statement),
+            "documentation": format_docstring(suggestion.description),
+            "additionalTextEdits": [edit],
+        }
+
+
+def get_names(script: Script) -> Set[str]:
+    """Get all names to ignore from the current file."""
+    raw_names = script.get_names(definitions=True)
+    log.debug(raw_names)
+    return set(name.name for name in raw_names)
+
+
+@hookimpl
+def pylsp_completions(config: Config, workspace: Workspace, document: Document, position):
+    """Get autoimport suggestions."""
+    line = document.lines[position["line"]]
+    expr = parso.parse(line)
+    word_node = expr.get_leaf_for_position((1, position["character"]))
+    if not _should_insert(expr, word_node):
+        return []
+    word = word_node.value
+    log.debug(f"autoimport: searching for word: {word}")
+    rope_config = config.settings(document_path=document.path).get("rope", {})
+    ignored_names: Set[str] = get_names(document.jedi_script(use_document_path=True))
+    autoimport = workspace._rope_autoimport(rope_config)
+    suggestions = list(autoimport.search_full(word, ignored_names=ignored_names))
+    results = list(
+        sorted(
+            _process_statements(suggestions, document.uri, word, autoimport, document),
+            key=lambda statement: statement["sortText"],
+        )
+    )
+    if len(results) > MAX_RESULTS:
+        results = results[:MAX_RESULTS]
+    return results
+
+
+def _document(import_statement: str) -> str:
+    return """# Auto-Import\n""" + import_statement + "\n"
+
+
+def _get_score(source: int, full_statement: str, suggested_name: str, desired_name) -> int:
+    import_length = len("import")
+    full_statement_score = len(full_statement) - import_length
+    suggested_name_score = ((len(suggested_name) - len(desired_name))) ** 2
+    source_score = 20 * source
+    return suggested_name_score + full_statement_score + source_score
+
+
+def _sort_import(score: int) -> str:
+    score = max(min(score, (_score_max) - 1), 0)
+    # Since we are using ints, we need to pad them.
+    # We also want to prioritize autoimport behind everything since its the last priority.
+    # The minimum is to prevent score from overflowing the pad
+    return "[z" + str(score).rjust(_score_pow, "0")
+
+
+@hookimpl
+def pylsp_initialize(config: Config, workspace: Workspace):
+    """Initialize AutoImport. Generates the cache for local and global items."""
+    memory: bool = config.plugin_settings("rope_autoimport").get("memory", False)
+    rope_config = config.settings().get("rope", {})
+    autoimport = workspace._rope_autoimport(rope_config, memory)
+    autoimport.generate_modules_cache()
+    autoimport.generate_cache()
+
+
+@hookimpl
+def pylsp_document_did_save(config: Config, workspace: Workspace, document: Document):
+    """Update the names associated with this document."""
+    rope_config = config.settings().get("rope", {})
+    rope_doucment: Resource = document._rope_resource(rope_config)
+    autoimport = workspace._rope_autoimport(rope_config)
+    autoimport.generate_cache(resources=[rope_doucment])
+    # Might as well using saving the document as an indicator to regenerate the module cache
+    autoimport.generate_modules_cache()

--- a/pylsp/plugins/rope_autoimport.py
+++ b/pylsp/plugins/rope_autoimport.py
@@ -45,7 +45,10 @@ def _should_insert(expr: tree.BaseNode, word_node: tree.Leaf) -> bool:
     if first_child == word_node:
         return True  # If the word is the first word then its fine
     if len(expr.children) > 1:
-        if any(node.type == "operator" and "." in node.value or node.type == "trailer" for node in expr.children):
+        if any(
+            node.type == "operator" and "." in node.value or node.type == "trailer"
+            for node in expr.children
+        ):
             return False  # Check if we're on a method of a function
     if isinstance(first_child, (tree.PythonErrorNode, tree.PythonNode)):
         # The tree will often include error nodes like this to indicate errors
@@ -54,7 +57,9 @@ def _should_insert(expr: tree.BaseNode, word_node: tree.Leaf) -> bool:
     return _handle_first_child(first_child, expr, word_node)
 
 
-def _handle_first_child(first_child: NodeOrLeaf, expr: tree.BaseNode, word_node: tree.Leaf) -> bool:
+def _handle_first_child(
+    first_child: NodeOrLeaf, expr: tree.BaseNode, word_node: tree.Leaf
+) -> bool:
     """Check if we suggest imports given the following first child."""
     if isinstance(first_child, tree.Import):
         return False
@@ -119,7 +124,9 @@ def _process_statements(
         start = {"line": insert_line, "character": 0}
         edit_range = {"start": start, "end": start}
         edit = {"range": edit_range, "newText": suggestion.import_statement + "\n"}
-        score = _get_score(suggestion.source, suggestion.import_statement, suggestion.name, word)
+        score = _get_score(
+            suggestion.source, suggestion.import_statement, suggestion.name, word
+        )
         if score > _score_max:
             continue
         # TODO make this markdown
@@ -128,7 +135,8 @@ def _process_statements(
             "kind": suggestion.itemkind,
             "sortText": _sort_import(score),
             "data": {"doc_uri": doc_uri},
-            "detail": _document(suggestion.import_statement),
+            "detail": _document(suggestion.modname),
+            "labelDetails": {"description": suggestion.modname},
             "documentation": format_docstring(suggestion.description),
             "additionalTextEdits": [edit],
         }
@@ -142,7 +150,9 @@ def get_names(script: Script) -> Set[str]:
 
 
 @hookimpl
-def pylsp_completions(config: Config, workspace: Workspace, document: Document, position):
+def pylsp_completions(
+    config: Config, workspace: Workspace, document: Document, position
+):
     """Get autoimport suggestions."""
     line = document.lines[position["line"]]
     expr = parso.parse(line)
@@ -170,7 +180,9 @@ def _document(import_statement: str) -> str:
     return """# Auto-Import\n""" + import_statement + "\n"
 
 
-def _get_score(source: int, full_statement: str, suggested_name: str, desired_name) -> int:
+def _get_score(
+    source: int, full_statement: str, suggested_name: str, desired_name
+) -> int:
     import_length = len("import")
     full_statement_score = len(full_statement) - import_length
     suggested_name_score = ((len(suggested_name) - len(desired_name))) ** 2

--- a/pylsp/plugins/rope_autoimport.py
+++ b/pylsp/plugins/rope_autoimport.py
@@ -57,9 +57,7 @@ def _should_insert(expr: tree.BaseNode, word_node: tree.Leaf) -> bool:
     return _handle_first_child(first_child, expr, word_node)
 
 
-def _handle_first_child(
-    first_child: NodeOrLeaf, expr: tree.BaseNode, word_node: tree.Leaf
-) -> bool:
+def _handle_first_child(first_child: NodeOrLeaf, expr: tree.BaseNode, word_node: tree.Leaf) -> bool:
     """Check if we suggest imports given the following first child."""
     if isinstance(first_child, tree.Import):
         return False
@@ -124,9 +122,7 @@ def _process_statements(
         start = {"line": insert_line, "character": 0}
         edit_range = {"start": start, "end": start}
         edit = {"range": edit_range, "newText": suggestion.import_statement + "\n"}
-        score = _get_score(
-            suggestion.source, suggestion.import_statement, suggestion.name, word
-        )
+        score = _get_score(suggestion.source, suggestion.import_statement, suggestion.name, word)
         if score > _score_max:
             continue
         # TODO make this markdown
@@ -150,9 +146,7 @@ def get_names(script: Script) -> Set[str]:
 
 
 @hookimpl
-def pylsp_completions(
-    config: Config, workspace: Workspace, document: Document, position
-):
+def pylsp_completions(config: Config, workspace: Workspace, document: Document, position):
     """Get autoimport suggestions."""
     line = document.lines[position["line"]]
     expr = parso.parse(line)
@@ -180,9 +174,7 @@ def _document(import_statement: str) -> str:
     return """# Auto-Import\n""" + import_statement + "\n"
 
 
-def _get_score(
-    source: int, full_statement: str, suggested_name: str, desired_name
-) -> int:
+def _get_score(source: int, full_statement: str, suggested_name: str, desired_name) -> int:
     import_length = len("import")
     full_statement_score = len(full_statement) - import_length
     suggested_name_score = ((len(suggested_name) - len(desired_name))) ** 2

--- a/test/plugins/test_autoimport.py
+++ b/test/plugins/test_autoimport.py
@@ -1,0 +1,225 @@
+# Copyright 2022- Python Language Server Contributors.
+
+from typing import Dict, List
+from unittest.mock import Mock
+
+import jedi
+import parso
+import pytest
+
+from pylsp import lsp, uris
+from pylsp.config.config import Config
+from pylsp.plugins.rope_autoimport import _get_score, _should_insert, get_names
+from pylsp.plugins.rope_autoimport import pylsp_completions as pylsp_autoimport_completions
+from pylsp.plugins.rope_autoimport import pylsp_initialize
+from pylsp.workspace import Workspace
+
+DOC_URI = uris.from_fs_path(__file__)
+
+
+@pytest.fixture(scope="session")
+def autoimport_workspace(tmp_path_factory) -> Workspace:
+    "Special autoimport workspace. Persists across sessions to make in-memory sqlite3 database fast."
+    workspace = Workspace(uris.from_fs_path(str(tmp_path_factory.mktemp("pylsp"))), Mock())
+    workspace._config = Config(workspace.root_uri, {}, 0, {})
+    workspace._config.update({"rope_autoimport": {"memory": True, "enabled": True}})
+    pylsp_initialize(workspace._config, workspace)
+    yield workspace
+    workspace.close()
+
+
+# pylint: disable=redefined-outer-name
+@pytest.fixture
+def completions(config: Config, autoimport_workspace: Workspace, request):
+    document, position = request.param
+    if position < 0:
+        position = len(document) + position
+    com_position = {"line": 0, "character": position}
+    autoimport_workspace.put_document(DOC_URI, source=document)
+    doc = autoimport_workspace.get_document(DOC_URI)
+    yield pylsp_autoimport_completions(config, autoimport_workspace, doc, com_position)
+    autoimport_workspace.rm_document(DOC_URI)
+
+
+def should_insert(phrase: str, position: int):
+    expr = parso.parse(phrase)
+    word_node = expr.get_leaf_for_position((1, position))
+    return _should_insert(expr, word_node)
+
+
+def check_dict(query: Dict, results: List[Dict]) -> Dict:
+    for result in results:
+        if all(result[key] == query[key] for key in query.keys()):
+            return result
+    return None
+
+
+@pytest.mark.parametrize("completions", [("""pathli """, 6)], indirect=True)
+def test_autoimport_completion(completions):
+    assert completions
+    assert check_dict({"label": "pathlib", "kind": lsp.CompletionItemKind.Module}, completions)
+
+
+@pytest.mark.parametrize("completions", [("""import """, 7)], indirect=True)
+def test_autoimport_import(completions):
+    assert len(completions) == 0
+
+
+@pytest.mark.parametrize("completions", [("""pathlib""", 2)], indirect=True)
+def test_autoimport_pathlib(completions):
+    assert completions[0]["label"] == "pathlib"
+
+    start = {"line": 0, "character": 0}
+    edit_range = {"start": start, "end": start}
+    assert completions[0]["additionalTextEdits"] == [{"range": edit_range, "newText": "import pathlib\n"}]
+
+
+@pytest.mark.parametrize("completions", [("""Pat""", -1)], indirect=True)
+def test_autoimport_pathlib2(completions):
+    assert completions[0]["label"] == "Path"
+
+    start = {"line": 0, "character": 0}
+    edit_range = {"start": start, "end": start}
+    assert completions[0]["documentation"] != ""
+
+
+@pytest.mark.parametrize("completions", [("""import test\n""", 10)], indirect=True)
+def test_autoimport_import_with_name(completions):
+    assert len(completions) == 0
+
+
+@pytest.mark.parametrize("completions", [("""def func(s""", 10)], indirect=True)
+def test_autoimport_function(completions):
+
+    assert len(completions) == 0
+
+
+@pytest.mark.parametrize("completions", [("""class Test""", 10)], indirect=True)
+def test_autoimport_class(completions):
+    assert len(completions) == 0
+
+
+@pytest.mark.parametrize("completions", [("""class Test(NamedTupl):""", 20)], indirect=True)
+def test_autoimport_class_complete(completions):
+    assert len(completions) > 0
+
+
+@pytest.mark.parametrize("completions", [("""class Test(NamedTupl""", 20)], indirect=True)
+def test_autoimport_class_incomplete(completions):
+    assert len(completions) > 0
+
+
+@pytest.mark.parametrize("completions", [("""def func(s:Lis""", 12)], indirect=True)
+def test_autoimport_function_typing(completions):
+    assert len(completions) > 0
+    assert check_dict({"label": "List"}, completions)
+
+
+@pytest.mark.parametrize("completions", [("""def func(s : Lis ):""", 16)], indirect=True)
+def test_autoimport_function_typing_complete(completions):
+    assert len(completions) > 0
+    assert check_dict({"label": "List"}, completions)
+
+
+@pytest.mark.parametrize("completions", [("""def func(s : Lis ) -> Generat:""", 29)], indirect=True)
+def test_autoimport_function_typing_return(completions):
+    assert len(completions) > 0
+    assert check_dict({"label": "Generator"}, completions)
+
+
+def test_autoimport_defined_name(config, workspace):
+    document = """List = "hi"\nLis"""
+    com_position = {"line": 1, "character": 3}
+    workspace.put_document(DOC_URI, source=document)
+    doc = workspace.get_document(DOC_URI)
+    completions = pylsp_autoimport_completions(config, workspace, doc, com_position)
+    workspace.rm_document(DOC_URI)
+    assert not check_dict({"label": "List"}, completions)
+
+
+# This test has several large issues.
+# 1. autoimport relies on its sources being written to disk. This makes testing harder
+# 2. the hook doesn't handle removed files
+# 3. The testing framework cannot access the actual autoimport object so it cannot clear the cache
+# def test_autoimport_update_module(config: Config, workspace: Workspace):
+#     document2 = "SomethingYouShouldntWrite = 1"
+#     document = """SomethingYouShouldntWrit"""
+#     com_position = {
+#         "line": 0,
+#         "character": 3,
+#     }
+#     doc2_path = workspace.root_path + "/test_file_no_one_should_write_to.py"
+#     if os.path.exists(doc2_path):
+#         os.remove(doc2_path)
+#     DOC2_URI = uris.from_fs_path(doc2_path)
+#     workspace.put_document(DOC_URI, source=document)
+#     doc = workspace.get_document(DOC_URI)
+#     completions = pylsp_autoimport_completions(config, workspace, doc, com_position)
+#     assert len(completions) == 0
+#     with open(doc2_path, "w") as f:
+#         f.write(document2)
+#     workspace.put_document(DOC2_URI, source=document2)
+#     doc2 = workspace.get_document(DOC2_URI)
+#     pylsp_document_did_save(config, workspace, doc2)
+#     assert check_dict({"label": "SomethingYouShouldntWrite"}, completions)
+#     workspace.put_document(DOC2_URI, source="\n")
+#     doc2 = workspace.get_document(DOC2_URI)
+#     os.remove(doc2_path)
+#     pylsp_document_did_save(config, workspace, doc2)
+#     completions = pylsp_autoimport_completions(config, workspace, doc, com_position)
+#     assert len(completions) == 0
+#     workspace.rm_document(DOC_URI)
+
+
+class TestShouldInsert:
+    def test_dot(self):
+
+        assert not should_insert("""str.""", 4)
+
+    def test_dot_partial(self):
+
+        assert not should_insert("""str.metho\n""", 9)
+
+    def test_comment(self):
+        assert not should_insert("""#""", 1)
+
+    def test_comment_indent(self):
+
+        assert not should_insert("""    # """, 5)
+
+    def test_from(self):
+        assert not should_insert("""from """, 5)
+        assert should_insert("""from """, 4)
+
+
+def test_sort_sources():
+    result1 = _get_score(1, "import pathlib", "pathlib", "pathli")
+    result2 = _get_score(2, "import pathlib", "pathlib", "pathli")
+    assert result1 < result2
+
+
+def test_sort_statements():
+    result1 = _get_score(2, "from importlib_metadata import pathlib", "pathlib", "pathli")
+    result2 = _get_score(2, "import pathlib", "pathlib", "pathli")
+    assert result1 > result2
+
+
+def test_sort_both():
+    result1 = _get_score(3, "from importlib_metadata import pathlib", "pathlib", "pathli")
+    result2 = _get_score(2, "import pathlib", "pathlib", "pathli")
+    assert result1 > result2
+
+
+def test_get_names():
+    source = """
+    from a import s as e
+    import blah, bleh
+    hello = "str"
+    a, b = 1, 2
+    def someone():
+        soemthing
+    class sfa:
+        sfiosifo
+    """
+    results = get_names(jedi.Script(code=source))
+    assert results == set(["blah", "bleh", "e", "hello", "someone", "sfa", "a", "b"])

--- a/test/plugins/test_autoimport.py
+++ b/test/plugins/test_autoimport.py
@@ -71,7 +71,9 @@ def test_autoimport_pathlib(completions):
 
     start = {"line": 0, "character": 0}
     edit_range = {"start": start, "end": start}
-    assert completions[0]["additionalTextEdits"] == [{"range": edit_range, "newText": "import pathlib\n"}]
+    assert completions[0]["additionalTextEdits"] == [
+        {"range": edit_range, "newText": "import pathlib\n"}
+    ]
 
 
 @pytest.mark.parametrize("completions", [("""Pat""", -1)], indirect=True)


### PR DESCRIPTION
Autoimport can now cache docs for some objects and display them in pylsp
Dependencies:
- PR in rope
- Basic Autoimport PR
- Some other stuff I'm probably forgetting

![image](https://user-images.githubusercontent.com/57874654/199662301-6d438f9a-8815-4dbc-adb4-7273578d0d8c.png)
Does pyright or pycharm have this feature?
