### PR TITLE
Support Flake8 version 6

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/cache@v1
         with:
           path: ~/.cache/pip
-          key: static-pip-${{ hashFiles('setup.py') }}
+          key: static-pip-${{ hashFiles('pyproject.toml') }}
           restore-keys: static-pip-
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/cache@v1
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-${{ matrix.PYTHON_VERSION }}-pip-${{ hashFiles('setup.py') }}
+          key: ${{ runner.os }}-${{ matrix.PYTHON_VERSION }}-pip-${{ hashFiles('pyproject.toml') }}
           restore-keys: ${{ runner.os }}-${{ matrix.PYTHON_VERSION }}-pip-
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -34,7 +34,6 @@ jobs:
           python-version: ${{ matrix.PYTHON_VERSION }}
           architecture: 'x64'
       - name: Create Jedi environment for testing
-        if: matrix.PYTHON_VERSION != '2.7'
         run: |
           python3 -m venv /tmp/pyenv
           /tmp/pyenv/bin/python -m pip install loghub

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/cache@v1
         with:
           path: ~/Library/Caches/pip
-          key: ${{ runner.os }}-${{ matrix.PYTHON_VERSION }}-pip-${{ hashFiles('setup.py') }}
+          key: ${{ runner.os }}-${{ matrix.PYTHON_VERSION }}-pip-${{ hashFiles('pyproject.toml') }}
           restore-keys: ${{ runner.os }}-${{ matrix.PYTHON_VERSION }}-pip-
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -34,7 +34,6 @@ jobs:
           python-version: ${{ matrix.PYTHON_VERSION }}
           architecture: 'x64'
       - name: Create Jedi environment for testing
-        if: matrix.PYTHON_VERSION != '2.7'
         run: |
           python3 -m venv /tmp/pyenv
           /tmp/pyenv/bin/python -m pip install loghub

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/cache@v1
         with:
           path: ~\AppData\Local\pip\Cache
-          key: ${{ runner.os }}-${{ matrix.PYTHON_VERSION }}-pip-${{ hashFiles('setup.py') }}
+          key: ${{ runner.os }}-${{ matrix.PYTHON_VERSION }}-pip-${{ hashFiles('pyproject.toml') }}
           restore-keys: ${{ runner.os }}-${{ matrix.PYTHON_VERSION }}-pip-
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,22 +28,22 @@ Homepage = "https://github.com/python-lsp/python-lsp-server"
 [project.optional-dependencies]
 all = [
     "autopep8>=1.6.0,<1.7.0",
-    "flake8>=5.0.0,<5.1.0",
+    "flake8>=5.0.0,<7",
     "mccabe>=0.7.0,<0.8.0",
-    "pycodestyle>=2.9.0,<2.10.0",
+    "pycodestyle>=2.9.0,<2.11.0",
     "pydocstyle>=2.0.0",
-    "pyflakes>=2.5.0,<2.6.0",
+    "pyflakes>=2.5.0,<3.1.0",
     "pylint>=2.5.0",
     "rope>1.2.0",
     "yapf",
     "whatthepatch"
 ]
 autopep8 = ["autopep8>=1.6.0,<1.7.0"]
-flake8 = ["flake8>=5.0.0,<5.1.0"]
+flake8 = ["flake8>=5.0.0,<7"]
 mccabe = ["mccabe>=0.7.0,<0.8.0"]
-pycodestyle = ["pycodestyle>=2.9.0,<2.10.0"]
+pycodestyle = ["pycodestyle>=2.9.0,<2.11.0"]
 pydocstyle = ["pydocstyle>=2.0.0"]
-pyflakes = ["pyflakes>=2.5.0,<2.6.0"]
+pyflakes = ["pyflakes>=2.5.0,<3.1.0"]
 pylint = ["pylint>=2.5.0"]
 rope = ["rope>1.2.0"]
 yapf = ["yapf", "whatthepatch>=1.0.2,<2.0.0"]


### PR DESCRIPTION
Flake8 v6 is out and requires more recent pycodestyle and pyflakes.

No code changes needed. The API was kept stable enough.