### PR TITLE
Ensure proper document match to avoid empty outline (Symbols)

### DIFF
--- a/pylsp/plugins/symbols.py
+++ b/pylsp/plugins/symbols.py
@@ -91,7 +91,7 @@ def pylsp_document_symbols(config, document):
                 else:
                     continue
 
-        if _include_def(d) and Path(document.path) == d.module_path:
+        if _include_def(d) and Path(document.path) == Path(d.module_path):
             tuple_range = _tuple_range(d)
             if tuple_range in exclude:
                 continue


### PR DESCRIPTION
... also if module_path is not a Path

Mileage may vary, but at least on my setup some sprinkled logging shows that `d.module_path` is not a `Path` (but rather string), so the comparison turns `False`, and so the result is an empty outline.  Wrapping it in `Path` should make it work whether or not it is a `Path`.