### PR TITLE
Fix Pycodestyle linting with line endings other than LF 

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - '*'
 
+concurrency:
+  group: static-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Static code analysis

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - '*'
 
+concurrency:
+  group: test-linux-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Linux Py${{ matrix.PYTHON_VERSION }}
@@ -41,7 +45,7 @@ jobs:
       - run: pip install -e .[all,test]
       - name: Show test environment
         run: pip list
-      - run: pytest -v test/
+      - run: pytest --color=yes -v test/
       # Enable this if SSH debugging is required
       # - name: Setup tmate session
       #   uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - '*'
 
+concurrency:
+  group: test-mac-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Mac Py${{ matrix.PYTHON_VERSION }}
@@ -41,7 +45,7 @@ jobs:
       - run: pip install -e .[all,test]
       - name: Show test environment
         run: pip list
-      - run: pytest -v test/
+      - run: pytest --color=yes -v test/
       # Enable this if SSH debugging is required
       # - name: Setup tmate session
       #   uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - '*'
 
+concurrency:
+  group: test-win-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Win Py${{ matrix.PYTHON_VERSION }}
@@ -37,4 +41,4 @@ jobs:
       - run: pip install -e .[all,test]
       - name: Show test environment
         run: pip list
-      - run: pytest -v test/
+      - run: pytest --color=yes -v test/

--- a/test/plugins/test_pycodestyle_lint.py
+++ b/test/plugins/test_pycodestyle_lint.py
@@ -122,8 +122,7 @@ def test_line_endings(workspace, newline):
     other than LF.
     """
     # Create simple source that should give false positives
-    source = "try:\n    1/0\nexcept Exception:\n    pass\n"
-    source = source.replace('\n', newline)
+    source = f"try:{newline}    1/0{newline}except Exception:{newline}    pass{newline}"
 
     # Create document
     doc = Document(DOC_URI, workspace, source)

--- a/test/plugins/test_pycodestyle_lint.py
+++ b/test/plugins/test_pycodestyle_lint.py
@@ -122,7 +122,7 @@ def test_line_endings(workspace, newline):
     other than LF.
     """
     # Create simple source that should give false positives
-    source = "try:\n    1/0\nexcept:\n    pass\n"
+    source = "try:\n    1/0\nexcept Exception:\n    pass\n"
     source = source.replace('\n', newline)
 
     # Create document

--- a/test/plugins/test_pycodestyle_lint.py
+++ b/test/plugins/test_pycodestyle_lint.py
@@ -2,6 +2,9 @@
 # Copyright 2021- Python Language Server Contributors.
 
 import os
+
+import pytest
+
 from pylsp import lsp, uris
 from pylsp.workspace import Document
 from pylsp.plugins import pycodestyle_lint
@@ -110,3 +113,23 @@ def test_pycodestyle_config(workspace):
     assert not [d for d in diags if d['code'] == 'W191']
     assert not [d for d in diags if d['code'] == 'E201']
     assert [d for d in diags if d['code'] == 'W391']
+
+
+@pytest.mark.parametrize('newline', ['\r\n', '\r'])
+def test_line_endings(workspace, newline):
+    """
+    Check that Pycodestyle doesn't generate false positives with line endings
+    other than LF.
+    """
+    # Create simple source that should give false positives
+    source = "try:\n    1/0\nexcept:\n    pass\n"
+    source = source.replace('\n', newline)
+
+    # Create document
+    doc = Document(DOC_URI, workspace, source)
+
+    # Get diagnostics
+    diags = pycodestyle_lint.pylsp_lint(workspace, doc)
+
+    # Assert no diagnostics were given
+    assert len(diags) == 0


### PR DESCRIPTION
- See spyder-ide/spyder#19565 for context.
- Also, cancel runs in progress and make pytest color its output on CIs.