### PR TITLE
Change Pylint run to set cwd correctly

### DIFF
--- a/test/plugins/test_pylint_lint.py
+++ b/test/plugins/test_pylint_lint.py
@@ -3,11 +3,12 @@
 # Copyright 2021- Python Language Server Contributors.
 
 import contextlib
+from pathlib import Path
 import os
 import tempfile
 
 from pylsp import lsp, uris
-from pylsp.workspace import Document
+from pylsp.workspace import Document, Workspace
 from pylsp.plugins import pylint_lint
 
 DOC_URI = uris.from_fs_path(__file__)
@@ -90,8 +91,9 @@ def test_lint_free_pylint(config, workspace):
     # Can't use temp_document because it might give us a file that doesn't
     # match pylint's naming requirements. We should be keeping this file clean
     # though, so it works for a test of an empty lint.
+    ws = Workspace(str(Path(__file__).absolute().parents[2]), workspace._endpoint)
     assert not pylint_lint.pylsp_lint(
-        config, workspace, Document(uris.from_fs_path(__file__), workspace), True)
+        config, ws, Document(uris.from_fs_path(__file__), ws), True)
 
 
 def test_lint_caching(workspace):


### PR DESCRIPTION
Since `__init__.py` are not necessary using the pylint plugins will miss configuration files is such files are not present.

### Explanation

In `pylsp.plugins/pylint_lint.py` the use `py_run` (from `pylint.epylint`) will not use the proper working directory.

If `__init__.py` are not present as `py_run` will call `lint` from the same file. The `lint` function traverse parent folder as long as a `__init__.py` is present (see https://github.com/PyCQA/pylint/blob/main/pylint/epylint.py#L65).

Directly calling `Run` from `pylint.lint` can enable proper usage of `cwd` exactly as the flake8 plugins does (set to `document._workspace.root_path`, see https://github.com/python-lsp/python-lsp-server/blob/develop/pylsp/plugins/flake8_lint.py#L114).

### Additional Points

`py_run` is deprecated and to be removed in pylint 3.0 : https://github.com/PyCQA/pylint/blob/main/pylint/epylint.py#L171

If anything can be improved in this PR I will gladly make any change suggested.