### PR TITLE
Don't show signature for modules in hovers

### DIFF
--- a/pylsp/plugins/hover.py
+++ b/pylsp/plugins/hover.py
@@ -36,7 +36,7 @@ def pylsp_hover(config, document, position):
             x.to_string() for x in definition.get_signatures()
             if (x.name == word and x.type not in ["module"])
         ),
-         ''
+        ''
     )
 
     return {

--- a/pylsp/plugins/hover.py
+++ b/pylsp/plugins/hover.py
@@ -31,8 +31,13 @@ def pylsp_hover(config, document, position):
     preferred_markup_kind = _utils.choose_markup_kind(supported_markup_kinds)
 
     # Find first exact matching signature
-    signature = next((x.to_string() for x in definition.get_signatures()
-                      if x.name == word), '')
+    signature = next(
+        (
+            x.to_string() for x in definition.get_signatures()
+            if (x.name == word and x.type not in ["module"])
+        ),
+         ''
+    )
 
     return {
         'contents': _utils.format_docstring(


### PR DESCRIPTION
Modules are not callables, so there's no need to show a signature for them.