### PR TITLE
Use `sys.executable` instead of `python` in Pylint plugin

### DIFF
--- a/pylsp/plugins/pylint_lint.py
+++ b/pylsp/plugins/pylint_lint.py
@@ -85,7 +85,7 @@ class PylintLinter:
             return cls.last_diags[document.path]
 
         cmd = [
-            'python',
+            sys.executable,
             '-c',
             'import sys; from pylint.lint import Run; Run(sys.argv[1:])',
             '-f',


### PR DESCRIPTION
Similar to #111, the plugin should not assume that there is a `python` command in the PATH. (See also [PEP394](https://peps.python.org/pep-0394/))