### PR TITLE
Fix pydocstyle linting with its 6.2.0 version

### DIFF
--- a/pylsp/plugins/pydocstyle_lint.py
+++ b/pylsp/plugins/pydocstyle_lint.py
@@ -66,9 +66,9 @@ def pylsp_lint(config, workspace, document):
 
         # Will only yield a single filename, the document path
         diags = []
-        for filename, checked_codes, ignore_decorators in conf.get_files_to_check():
+        for filename, checked_codes, ignore_decorators, property_decorators in conf.get_files_to_check():
             errors = pydocstyle.checker.ConventionChecker().check_source(
-                document.source, filename, ignore_decorators=ignore_decorators
+                document.source, filename, ignore_decorators=ignore_decorators, property_decorators=property_decorators
             )
 
             try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ all = [
     "flake8>=5.0.0,<7",
     "mccabe>=0.7.0,<0.8.0",
     "pycodestyle>=2.9.0,<2.11.0",
-    "pydocstyle>=2.0.0",
+    "pydocstyle>=6.2.0,<6.3.0",
     "pyflakes>=2.5.0,<3.1.0",
     "pylint>=2.5.0",
     "rope>1.2.0",
@@ -42,7 +42,7 @@ autopep8 = ["autopep8>=1.6.0,<1.7.0"]
 flake8 = ["flake8>=5.0.0,<7"]
 mccabe = ["mccabe>=0.7.0,<0.8.0"]
 pycodestyle = ["pycodestyle>=2.9.0,<2.11.0"]
-pydocstyle = ["pydocstyle>=2.0.0"]
+pydocstyle = ["pydocstyle>=6.2.0,<6.3.0"]
 pyflakes = ["pyflakes>=2.5.0,<3.1.0"]
 pylint = ["pylint>=2.5.0"]
 rope = ["rope>1.2.0"]


### PR DESCRIPTION
- This was caused by an API breakage in that version.
- Also add top constraint on pydocstyle to avoid this kind of errors in the future.

Fixes #332.