### PR TITLE
Fix or silence pylint warnings in `test_lint_free_pylint` test

### DIFF
--- a/pylsp/plugins/pylint_lint.py
+++ b/pylsp/plugins/pylint_lint.py
@@ -132,6 +132,7 @@ class PylintLinter:
         #  * warning
         diagnostics = []
         for diag in json.loads(json_out):
+            log.debug("Pylint raw output entry: %s", diag)
             # pylint lines index from 1, pylsp lines index from 0
             line = diag['line'] - 1
 

--- a/test/plugins/test_pylint_lint.py
+++ b/test/plugins/test_pylint_lint.py
@@ -91,9 +91,10 @@ def test_lint_free_pylint(config, workspace):
     # Can't use temp_document because it might give us a file that doesn't
     # match pylint's naming requirements. We should be keeping this file clean
     # though, so it works for a test of an empty lint.
-    ws = Workspace(str(Path(__file__).absolute().parents[2]), workspace._endpoint)
+    # pylint: disable-next=protected-access
+    wksp = Workspace(str(Path(__file__).absolute().parents[2]), workspace._endpoint)
     assert not pylint_lint.pylsp_lint(
-        config, ws, Document(uris.from_fs_path(__file__), ws), True)
+        config, wksp, Document(uris.from_fs_path(__file__), wksp), True)
 
 
 def test_lint_caching(workspace):


### PR DESCRIPTION
Building 1.7.0 for Debian, two tests failed: `test/plugins/test_pylint_lint.py::test_lint_free_pylint` and `test_per_file_caching`, first with the output
```
>       assert not pylint_lint.pylsp_lint(
            config, ws, Document(uris.from_fs_path(__file__), ws), True)
E       assert not [{'code': 'C0103', 'message': '[invalid-name] Variable name "ws" doesn\'t conform to snake_case naming style', 'range'...t class', 'range': {'end': {'character': 83, 'line': 94}, 'start': {'character': 62, 'line': 94}}, 'severity': 2, ...}]
```
and once I'd fixed that, then with the output
```
>       assert not pylint_lint.pylsp_lint(
            config, wksp, Document(uris.from_fs_path(__file__), wksp), True)
E       AssertionError: assert not [{'code': 'W0212', 'message': '[protected-access] Access to a protected member _endpoint of a client class', 'range': {'end': {'character': 85, 'line': 94}, 'start': {'character': 64, 'line': 94}}, 'severity': 2, ...}]
```
This patch addresses both of these two failures; the first by changing `ws` to `wksp` and the second by disabling this pylint warning (as there's no (public) accessor method for the `_endpoint` member.

The thing I really don't understand, though, is how this test passes on the GitHub CI system!  I'm using clean chroot and lxc containers to run the tests with a completely vanilla pylint 2.15.9 installation, just as GitHub CI is doing.