### PR TITLE
Add top constraint to Pylint and fix constraint for `whatthepatch`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ all = [
     "pycodestyle>=2.9.0,<2.11.0",
     "pydocstyle>=6.2.0,<6.3.0",
     "pyflakes>=2.5.0,<3.1.0",
-    "pylint>=2.5.0",
+    "pylint>=2.5.0,<3",
     "rope>1.2.0",
     "yapf",
     "whatthepatch"
@@ -44,12 +44,12 @@ mccabe = ["mccabe>=0.7.0,<0.8.0"]
 pycodestyle = ["pycodestyle>=2.9.0,<2.11.0"]
 pydocstyle = ["pydocstyle>=6.2.0,<6.3.0"]
 pyflakes = ["pyflakes>=2.5.0,<3.1.0"]
-pylint = ["pylint>=2.5.0"]
+pylint = ["pylint>=2.5.0,<3"]
 rope = ["rope>1.2.0"]
 yapf = ["yapf", "whatthepatch>=1.0.2,<2.0.0"]
 websockets = ["websockets>=10.3"]
 test = [
-    "pylint>=2.5.0",
+    "pylint>=2.5.0,<3",
     "pytest",
     "pytest-cov",
     "coverage",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ all = [
     "pylint>=2.5.0,<3",
     "rope>1.2.0",
     "yapf",
-    "whatthepatch"
+    "whatthepatch>=1.0.2,<2.0.0"
 ]
 autopep8 = ["autopep8>=1.6.0,<1.7.0"]
 flake8 = ["flake8>=5.0.0,<7"]


### PR DESCRIPTION
- This will save us from headaches when that major version is released.
- The constraint for `whatthepatch` was declared differently in two places.