### PR TITLE
Include missing Pylint "information" category

### DIFF
--- a/pylsp/plugins/pylint_lint.py
+++ b/pylsp/plugins/pylint_lint.py
@@ -126,6 +126,7 @@ class PylintLinter:
         # The type can be any of:
         #
         #  * convention
+        #  * information
         #  * error
         #  * fatal
         #  * refactor
@@ -150,6 +151,8 @@ class PylintLinter:
             }
 
             if diag['type'] == 'convention':
+                severity = lsp.DiagnosticSeverity.Information
+            elif diag['type'] == 'information':
                 severity = lsp.DiagnosticSeverity.Information
             elif diag['type'] == 'error':
                 severity = lsp.DiagnosticSeverity.Error


### PR DESCRIPTION
Well, it turns out my PR https://github.com/python-lsp/python-lsp-server/pull/330 failed because it raised a message in the "information" category (see https://pylint.pycqa.org/en/latest/user_guide/messages/messages_overview.html) which is not currently handled by the python-lsp-server code.  Here's a simple patch to handle this case.