### PR TITLE
Improve Jedi file completions for directories

### DIFF
--- a/pylsp/plugins/jedi_completion.py
+++ b/pylsp/plugins/jedi_completion.py
@@ -3,7 +3,6 @@
 
 import logging
 import os
-import os.path as osp
 
 import parso
 
@@ -222,7 +221,7 @@ def _format_completion(d, markup_kind: str, include_params=True, resolve=False, 
 
     # Adjustments for file completions
     if d.type == 'path':
-        path = osp.normpath(d.name)
+        path = os.path.normpath(d.name)
         path = path.replace('\\', '\\\\')
         path = path.replace('/', '\\/')
 
@@ -230,11 +229,11 @@ def _format_completion(d, markup_kind: str, include_params=True, resolve=False, 
         # at the end to ease additional file completions.
         if d.name.endswith(os.sep):
             if os.name == 'nt':
-                completion['insertText'] = path + '\\\\'
+                path = path + '\\\\'
             else:
-                completion['insertText'] = path + '\\/'
-        else:
-            completion['insertText'] = path
+                path = path + '\\/'
+
+        completion['insertText'] = path
 
     if include_params and not is_exception_class(d.name):
         snippet = _snippet(d, resolve_label_or_snippet)

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -528,3 +528,26 @@ mymodule.f"""
     com_position = {'line': 1, 'character': 10}
     completions = pylsp_jedi_completions(doc._config, doc, com_position)
     assert completions[0]['label'] == 'foo()'
+
+
+def test_file_completions(workspace, tmpdir):
+    # Create directory and a file to get completions for them.
+    # Note: `tmpdir`` is the root dir of the `workspace` fixture. That's why we use
+    # it here.
+    tmpdir.mkdir('bar')
+    file = tmpdir.join('foo.txt')
+    file.write('baz')
+
+    # Content of doc to test completion
+    doc_content = '"'
+    doc = Document(DOC_URI, workspace, doc_content)
+
+    # Request for completions
+    com_position = {'line': 0, 'character': 1}
+    completions = pylsp_jedi_completions(doc._config, doc, com_position)
+
+    # Check completions
+    assert len(completions) == 2
+    assert [c['kind'] == lsp.CompletionItemKind.File for c in completions]
+    assert completions[0]['insertText'] == ('bar' + '\\\\') if os.name == 'nt' else ('bar' + '\\/')
+    assert completions[1]['insertText'] == 'foo.txt"'


### PR DESCRIPTION
- Add escaped `os.sep` at the end of directory completions to ease introducing additional file completions.
- Add a test for file completions.