### PR TITLE
Bump pydocstyle to 6.3

### DIFF
--- a/pylsp/plugins/pydocstyle_lint.py
+++ b/pylsp/plugins/pydocstyle_lint.py
@@ -66,9 +66,19 @@ def pylsp_lint(config, workspace, document):
 
         # Will only yield a single filename, the document path
         diags = []
-        for filename, checked_codes, ignore_decorators, property_decorators in conf.get_files_to_check():
+        for (
+            filename,
+            checked_codes,
+            ignore_decorators,
+            property_decorators,
+            ignore_self_only_init,
+        ) in conf.get_files_to_check():
             errors = pydocstyle.checker.ConventionChecker().check_source(
-                document.source, filename, ignore_decorators=ignore_decorators, property_decorators=property_decorators
+                document.source,
+                filename,
+                ignore_decorators=ignore_decorators,
+                property_decorators=property_decorators,
+                ignore_self_only_init=ignore_self_only_init,
             )
 
             try:

--- a/pylsp/plugins/pydocstyle_lint.py
+++ b/pylsp/plugins/pydocstyle_lint.py
@@ -28,6 +28,7 @@ def pylsp_settings():
 
 @hookimpl
 def pylsp_lint(config, workspace, document):
+    # pylint: disable=too-many-locals
     with workspace.report_progress("lint: pydocstyle"):
         settings = config.plugin_settings('pydocstyle', document_path=document.path)
         log.debug("Got pydocstyle settings: %s", settings)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ all = [
     "flake8>=5.0.0,<7",
     "mccabe>=0.7.0,<0.8.0",
     "pycodestyle>=2.9.0,<2.11.0",
-    "pydocstyle>=6.2.0,<6.3.0",
+    "pydocstyle>=6.3.0,<6.4.0",
     "pyflakes>=2.5.0,<3.1.0",
     "pylint>=2.5.0,<3",
     "rope>1.2.0",
@@ -42,7 +42,7 @@ autopep8 = ["autopep8>=1.6.0,<1.7.0"]
 flake8 = ["flake8>=5.0.0,<7"]
 mccabe = ["mccabe>=0.7.0,<0.8.0"]
 pycodestyle = ["pycodestyle>=2.9.0,<2.11.0"]
-pydocstyle = ["pydocstyle>=6.2.0,<6.3.0"]
+pydocstyle = ["pydocstyle>=6.3.0,<6.4.0"]
 pyflakes = ["pyflakes>=2.5.0,<3.1.0"]
 pylint = ["pylint>=2.5.0,<3"]
 rope = ["rope>1.2.0"]


### PR DESCRIPTION
Unfortunate timing: pydocstyle also bumped their version yesterday with an API change.