### PR TITLE
Raise upper bound of autopep8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ Homepage = "https://github.com/python-lsp/python-lsp-server"
 
 [project.optional-dependencies]
 all = [
-    "autopep8>=1.6.0,<1.7.0",
+    "autopep8>=1.6.0,<2.1.0",
     "flake8>=5.0.0,<7",
     "mccabe>=0.7.0,<0.8.0",
     "pycodestyle>=2.9.0,<2.11.0",
@@ -39,7 +39,7 @@ all = [
     "toml",
     "whatthepatch>=1.0.2,<2.0.0"
 ]
-autopep8 = ["autopep8>=1.6.0,<1.7.0"]
+autopep8 = ["autopep8>=1.6.0,<2.1.0"]
 flake8 = ["flake8>=5.0.0,<7"]
 mccabe = ["mccabe>=0.7.0,<0.8.0"]
 pycodestyle = ["pycodestyle>=2.9.0,<2.11.0"]


### PR DESCRIPTION
There does not seem to be a relevant API change in autopep8 2.0 breaking compatibility with python-lsp-server