### PR TITLE
Fix empty cwd value for pylint

### DIFF
--- a/pylsp/plugins/pylint_lint.py
+++ b/pylsp/plugins/pylint_lint.py
@@ -48,7 +48,7 @@ class PylintLinter:
     last_diags = collections.defaultdict(list)
 
     @classmethod
-    def lint(cls, document, is_saved, flags=''):
+    def lint(cls, document, is_saved, flags=''):  # pylint: disable=too-many-locals,too-many-branches
         """Plugin interface to pylsp linter.
 
         Args:
@@ -96,7 +96,6 @@ class PylintLinter:
         log.debug("Calling pylint with '%s'", ' '.join(cmd))
 
         cwd = document._workspace.root_path
-
         if not cwd:
             cwd = os.path.dirname(__file__)
 

--- a/pylsp/plugins/pylint_lint.py
+++ b/pylsp/plugins/pylint_lint.py
@@ -95,8 +95,13 @@ class PylintLinter:
         ] + (shlex.split(str(flags)) if flags else [])
         log.debug("Calling pylint with '%s'", ' '.join(cmd))
 
+        cwd = document._workspace.root_path
+
+        if not cwd:
+            cwd = os.path.dirname(__file__)
+
         with Popen(cmd, stdout=PIPE, stderr=PIPE,
-                   cwd=document._workspace.root_path, universal_newlines=True) as process:
+                   cwd=cwd, universal_newlines=True) as process:
             process.wait()
             json_out = process.stdout.read()
             err = process.stderr.read()


### PR DESCRIPTION
Fixes https://github.com/python-lsp/python-lsp-server/issues/369

A shorter way to write this would be to use the walrus operator but that would require Python 3.8+ and the README states this project is Python 3.7+.
```python
if not (cwd := document._workspace.root_path):
    cwd = os.path.dirname(__file__)
```