### PR TITLE
Update yapf requirement to 0.33+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,7 @@ all = [
     "pyflakes>=2.5.0,<3.1.0",
     "pylint>=2.5.0,<3",
     "rope>1.2.0",
-    "yapf<=0.32.0",
-    "toml",
+    "yapf>=0.33.0",
     "whatthepatch>=1.0.2,<2.0.0"
 ]
 autopep8 = ["autopep8>=1.6.0,<2.1.0"]
@@ -47,7 +46,7 @@ pydocstyle = ["pydocstyle>=6.3.0,<6.4.0"]
 pyflakes = ["pyflakes>=2.5.0,<3.1.0"]
 pylint = ["pylint>=2.5.0,<3"]
 rope = ["rope>1.2.0"]
-yapf = ["yapf<=0.32.0", "whatthepatch>=1.0.2,<2.0.0", "toml"]
+yapf = ["yapf>=0.33.0", "whatthepatch>=1.0.2,<2.0.0"]
 websockets = ["websockets>=10.3"]
 test = [
     "pylint>=2.5.0,<3",


### PR DESCRIPTION
Reverts #346: Yapf 0.33 is out and requires tomli itself