### PR TITLE
Allow multiple hover results

### DIFF
--- a/pylsp/hookspecs.py
+++ b/pylsp/hookspecs.py
@@ -89,7 +89,7 @@ def pylsp_format_range(config, workspace, document, range, options):
     pass
 
 
-@hookspec(firstresult=True)
+@hookspec
 def pylsp_hover(config, workspace, document, position):
     pass
 

--- a/pylsp/python_lsp.py
+++ b/pylsp/python_lsp.py
@@ -369,7 +369,10 @@ class PythonLSPServer(MethodDispatcher):
         return flatten(self._hook('pylsp_document_highlight', doc_uri, position=position)) or None
 
     def hover(self, doc_uri, position):
-        return self._hook('pylsp_hover', doc_uri, position=position) or {'contents': ''}
+        out = self._hook('pylsp_hover', doc_uri, position=position)
+        if out:
+            return {'contents': [o['contents'] for o in out]}
+        return {'contents': ''}
 
     @_utils.debounce(LINT_DEBOUNCE_S, keyed_by='doc_uri')
     def lint(self, doc_uri, is_saved):


### PR DESCRIPTION
The language server already handles lists as contents, so this simple change allows for multiple results (e.g., from plugins) to be presented to the user.

This is interesting for use cases like https://github.com/python-lsp/pylsp-mypy/issues/63