### PR TITLE
Notebook protocol go-to-definition support

### DIFF
--- a/pylsp/python_lsp.py
+++ b/pylsp/python_lsp.py
@@ -679,14 +679,14 @@ class PythonLSPServer(MethodDispatcher):
         if notebookDocument is None:
             raise ValueError("Invalid notebook document")
 
-        cell_data = notebookDocument.cell_data(notebookDocument)
+        cell_data = notebookDocument.cell_data()
 
         # Concatenate all cells to be a single temporary document
-        total_source = "\n".join(cell.source for cell in cell_data.values())
+        total_source = "\n".join(data["source"] for data in cell_data.values())
         with workspace.temp_document(total_source) as temp_uri:
             # update position to be the position in the temp document
             if position is not None:
-                position += cell_data[cellDocument.uri]["line_start"]
+                position["line"] += cell_data[cellDocument.uri]["line_start"]
 
             definitions = self.definitions(temp_uri, position)
 

--- a/pylsp/python_lsp.py
+++ b/pylsp/python_lsp.py
@@ -593,11 +593,11 @@ class PythonLSPServer(MethodDispatcher):
                     # Cell documents
                     for cell_document in structure["didOpen"]:
                         workspace.put_cell_document(
-                            cell_document['uri'],
-                            notebookDocument['uri'],
-                            cell_document['languageId'],
-                            cell_document['text'],
-                            cell_document.get('version')
+                            cell_document["uri"],
+                            notebookDocument["uri"],
+                            cell_document["languageId"],
+                            cell_document["text"],
+                            cell_document.get("version"),
                         )
                     # Cell metadata which is added to Notebook
                     workspace.add_notebook_cells(
@@ -682,34 +682,38 @@ class PythonLSPServer(MethodDispatcher):
         cell_data = notebookDocument.cell_data(notebookDocument)
 
         # Concatenate all cells to be a single temporary document
-        total_source = '\n'.join(cell.source for cell in cell_data.values())
+        total_source = "\n".join(cell.source for cell in cell_data.values())
         with workspace.temp_document(total_source) as temp_uri:
             # update position to be the position in the temp document
             if position is not None:
-                position += cell_data[cellDocument.uri]['line_start']
+                position += cell_data[cellDocument.uri]["line_start"]
 
             definitions = self.definitions(temp_uri, position)
 
             # Translate temp_uri locations to cell document locations
             for definition in definitions:
-                if definition['uri'] == temp_uri:
+                if definition["uri"] == temp_uri:
                     # Find the cell the start line is in and adjust the uri and line numbers
                     for cell_uri, data in cell_data.items():
-                        if data['line_start'] <= definition['range']['start']['line'] <= data['line_end']:
-                            definition['uri'] = cell_uri
-                            definition['range']['start']['line'] -= data['line_start']
-                            definition['range']['end']['line'] -= data['line_start']
+                        if (
+                            data["line_start"]
+                            <= definition["range"]["start"]["line"]
+                            <= data["line_end"]
+                        ):
+                            definition["uri"] = cell_uri
+                            definition["range"]["start"]["line"] -= data["line_start"]
+                            definition["range"]["end"]["line"] -= data["line_start"]
                             break
 
             return definitions
 
     def m_text_document__definition(self, textDocument=None, position=None, **_kwargs):
         # textDocument here is just a dict with a uri
-        workspace = self._match_uri_to_workspace(textDocument['uri'])
-        document = workspace.get_document(textDocument['uri'])
+        workspace = self._match_uri_to_workspace(textDocument["uri"])
+        document = workspace.get_document(textDocument["uri"])
         if isinstance(document, Cell):
             return self._cell_document__definition(document, position, **_kwargs)
-        return self.definitions(textDocument['uri'], position)
+        return self.definitions(textDocument["uri"], position)
 
     def m_text_document__document_highlight(
         self, textDocument=None, position=None, **_kwargs

--- a/pylsp/python_lsp.py
+++ b/pylsp/python_lsp.py
@@ -634,8 +634,7 @@ class PythonLSPServer(MethodDispatcher):
         with workspace.temp_document(total_source) as random_uri:
             definitions = self.definitions(random_uri, position)
             for definition in definitions:
-                # TODO: a better test for if a definition is the random_uri
-                if random_uri in definition['uri']:
+                if random_uri == definition['uri']:
                     # Find the cell the start is in
                     for cell in cell_list:
                         # TODO: perhaps it is more correct to check definition['range']['end']['line'] <= cell['line_end'], but 

--- a/pylsp/python_lsp.py
+++ b/pylsp/python_lsp.py
@@ -484,7 +484,13 @@ class PythonLSPServer(MethodDispatcher):
             metadata=notebookDocument.get('metadata')
         )
         for cell in (cellTextDocuments or []):
-            workspace.put_cell_document(cell['uri'], notebookDocument['uri'], cell['languageId'], cell['text'], version=cell.get('version'))
+            workspace.put_cell_document(
+                cell['uri'],
+                notebookDocument['uri'],
+                cell['languageId'],
+                cell['text'],
+                version=cell.get('version')
+            )
         self.lint(notebookDocument['uri'], is_saved=True)
 
     def m_notebook_document__did_close(self, notebookDocument=None, cellTextDocuments=None, **_kwargs):
@@ -526,7 +532,7 @@ class PythonLSPServer(MethodDispatcher):
                     # Cell documents
                     for cell_document in structure['didOpen']:
                         workspace.put_cell_document(
-                            cell_document['uri'], 
+                            cell_document['uri'],
                             notebookDocument['uri'],
                             cell_document['languageId'],
                             cell_document['text'],

--- a/pylsp/workspace.py
+++ b/pylsp/workspace.py
@@ -119,6 +119,17 @@ class Workspace:
     def put_notebook_document(self, doc_uri, notebook_type, cells, version=None, metadata=None):
         self._docs[doc_uri] = self._create_notebook_document(doc_uri, notebook_type, cells, version, metadata)
 
+    @contextmanager
+    def temp_document(self, source):
+        random_uri = str(uuid.uuid4())
+        try:
+            self.put_document(random_uri, source)
+            yield random_uri
+        finally:
+            self.rm_document(random_uri)
+
+
+
     def add_notebook_cells(self, doc_uri, cells, start):
         self._docs[doc_uri].add_cells(cells, start)
 

--- a/pylsp/workspace.py
+++ b/pylsp/workspace.py
@@ -150,7 +150,9 @@ class Workspace:
     def update_notebook_metadata(self, doc_uri, metadata):
         self._docs[doc_uri].metadata = metadata
 
-    def put_cell_document(self, doc_uri, notebook_uri, language_id, source, version=None):
+    def put_cell_document(
+        self, doc_uri, notebook_uri, language_id, source, version=None
+    ):
         self._docs[doc_uri] = self._create_cell_document(
             doc_uri, notebook_uri, language_id, source, version
         )
@@ -351,7 +353,9 @@ class Workspace:
             metadata=metadata,
         )
 
-    def _create_cell_document(self, doc_uri, notebook_uri, language_id, source=None, version=None):
+    def _create_cell_document(
+        self, doc_uri, notebook_uri, language_id, source=None, version=None
+    ):
         # TODO: remove what is unnecessary here.
         path = uris.to_fs_path(doc_uri)
         return Cell(
@@ -606,16 +610,17 @@ class Notebook:
         cell_data = {}
         offset = 0
         for cell in self.cells:
-            cell_uri = cell['document']
+            cell_uri = cell["document"]
             cell_document = self.workspace.get_cell_document(cell_uri)
             num_lines = cell_document.line_count
             cell_data[cell_uri] = {
-                'line_start': offset,
-                'line_end': offset + num_lines - 1,
-                'source': cell_document.source
+                "line_start": offset,
+                "line_end": offset + num_lines - 1,
+                "source": cell_document.source,
             }
             offset += num_lines
         return cell_data
+
 
 class Cell(Document):
     """
@@ -630,7 +635,7 @@ class Cell(Document):
     def __init__(
         self,
         uri,
-        notebook_uri
+        notebook_uri,
         language_id,
         workspace,
         source=None,

--- a/pylsp/workspace.py
+++ b/pylsp/workspace.py
@@ -128,8 +128,8 @@ class Workspace:
     def update_notebook_metadata(self, doc_uri, metadata):
         self._docs[doc_uri].metadata = metadata
 
-    def put_cell_document(self, doc_uri, language_id, source, version=None):
-        self._docs[doc_uri] = self._create_cell_document(doc_uri, language_id, source, version)
+    def put_cell_document(self, doc_uri, notebook_uri, language_id, source, version=None):
+        self._docs[doc_uri] = self._create_cell_document(doc_uri, notebook_uri, language_id, source, version)
 
     def rm_document(self, doc_uri):
         self._docs.pop(doc_uri)
@@ -305,11 +305,12 @@ class Workspace:
             metadata=metadata
         )
 
-    def _create_cell_document(self, doc_uri, language_id, source=None, version=None):
+    def _create_cell_document(self, doc_uri, notebook_uri, language_id, source=None, version=None):
         # TODO: remove what is unnecessary here.
         path = uris.to_fs_path(doc_uri)
         return Cell(
             doc_uri,
+            notebook_uri=notebook_uri,
             language_id=language_id,
             workspace=self,
             source=source,
@@ -538,10 +539,11 @@ class Cell(Document):
     they have a language id.
     """
 
-    def __init__(self, uri, language_id, workspace, source=None, version=None, local=True, extra_sys_path=None,
+    def __init__(self, uri, notebook_uri, language_id, workspace, source=None, version=None, local=True, extra_sys_path=None,
                  rope_project_builder=None):
         super().__init__(uri, workspace, source, version, local, extra_sys_path, rope_project_builder)
         self.language_id = language_id
+        self.notebook_uri = notebook_uri
 
     @property
     @lock

--- a/pylsp/workspace.py
+++ b/pylsp/workspace.py
@@ -550,8 +550,8 @@ class Cell(Document):
     they have a language id.
     """
 
-    def __init__(self, uri, notebook_uri, language_id, workspace, source=None, version=None, local=True, extra_sys_path=None,
-                 rope_project_builder=None):
+    def __init__(self, uri, notebook_uri, language_id, workspace, source=None, version=None, local=True,
+                 extra_sys_path=None, rope_project_builder=None):
         super().__init__(uri, workspace, source, version, local, extra_sys_path, rope_project_builder)
         self.language_id = language_id
         self.notebook_uri = notebook_uri

--- a/pylsp/workspace.py
+++ b/pylsp/workspace.py
@@ -120,15 +120,15 @@ class Workspace:
         self._docs[doc_uri] = self._create_notebook_document(doc_uri, notebook_type, cells, version, metadata)
 
     @contextmanager
-    def temp_document(self, source):
-        random_uri = str(uuid.uuid4())
+    def temp_document(self, source, path=None):
+        if path is None:
+            path = self.root_path
+        uri = uris.from_fs_path(os.path.join(path, str(uuid.uuid4())))
         try:
-            self.put_document(random_uri, source)
-            yield random_uri
+            self.put_document(uri, source)
+            yield uri
         finally:
-            self.rm_document(random_uri)
-
-
+            self.rm_document(uri)
 
     def add_notebook_cells(self, doc_uri, cells, start):
         self._docs[doc_uri].add_cells(cells, start)

--- a/pylsp/workspace.py
+++ b/pylsp/workspace.py
@@ -539,6 +539,25 @@ class Notebook:
     def remove_cells(self, start: int, delete_count: int) -> None:
         del self.cells[start:start+delete_count]
 
+    def cell_data(self):
+        """Extract current cell data.
+
+        Returns a dict (ordered by cell position) where the key is the cell uri and the
+        value is a dict with line_start, line_end, and source attributes.
+        """
+        cell_data = {}
+        offset = 0
+        for cell in self.cells:
+            cell_uri = cell['document']
+            cell_document = self.workspace.get_cell_document(cell_uri)
+            num_lines = cell_document.line_count
+            cell_data[cell_uri] = {
+                'line_start': offset,
+                'line_end': offset + num_lines - 1,
+                'source': cell_document.source
+            }
+            offset += num_lines
+        return cell_data
 
 class Cell(Document):
     """

--- a/test/test_notebook_document.py
+++ b/test/test_notebook_document.py
@@ -545,10 +545,8 @@ def test_notebook__did_close(
         wait_for_condition(lambda: mock_notify.call_count >= 2)
         assert len(server.workspace.documents) == 0
 
-
-def test_notebook_definition(
-    client_server_pair,
-):  # pylint: disable=redefined-outer-name
+@pytest.mark.skipif(IS_WIN, reason="Flaky on Windows")
+def test_notebook_definition(client_server_pair):
     client, server = client_server_pair
     client._endpoint.request(
         "initialize",

--- a/test/test_notebook_document.py
+++ b/test/test_notebook_document.py
@@ -545,6 +545,7 @@ def test_notebook__did_close(
         wait_for_condition(lambda: mock_notify.call_count >= 2)
         assert len(server.workspace.documents) == 0
 
+
 @pytest.mark.skipif(IS_WIN, reason="Flaky on Windows")
 def test_notebook_definition(client_server_pair):
     client, server = client_server_pair

--- a/test/test_notebook_document.py
+++ b/test/test_notebook_document.py
@@ -583,6 +583,7 @@ def test_notebook__did_close(
         wait_for_condition(lambda: mock_notify.call_count >= 2)
         assert len(server.workspace.documents) == 0
 
+
 def test_notebook_definition(
     client_server_pair,
 ):  # pylint: disable=redefined-outer-name
@@ -641,23 +642,16 @@ def test_notebook_definition(
             "textDocument": {
                 "uri": "cell_2_uri",
             },
-            "position": {
-                "line": 0,
-                "character": 1
-            }
+            "position": {"line": 0, "character": 1},
         },
     )
     result = future.result(CALL_TIMEOUT_IN_SECONDS)
-    assert result == [{
-        'uri': 'cell_1_uri',
-        'range': {
-            'start': {
-                'line': 1,
-                'character': 0
+    assert result == [
+        {
+            "uri": "cell_1_uri",
+            "range": {
+                "start": {"line": 1, "character": 0},
+                "end": {"line": 1, "character": 1},
             },
-            'end': {
-                'line': 1,
-                'character': 1
-            }
         }
-    }]
+    ]

--- a/test/test_workspace.py
+++ b/test/test_workspace.py
@@ -7,6 +7,7 @@ from pylsp import uris
 
 
 DOC_URI = uris.from_fs_path(__file__)
+NOTEBOOK_URI = uris.from_fs_path('notebook_uri')
 
 
 def path_as_uri(path):
@@ -29,7 +30,7 @@ def test_put_notebook_document(pylsp):
 
 
 def test_put_cell_document(pylsp):
-    pylsp.workspace.put_cell_document(DOC_URI, 'python', 'content')
+    pylsp.workspace.put_cell_document(DOC_URI, NOTEBOOK_URI, 'python', 'content')
     assert DOC_URI in pylsp.workspace._docs
 
 

--- a/test/test_workspace.py
+++ b/test/test_workspace.py
@@ -7,7 +7,7 @@ from pylsp import uris
 
 
 DOC_URI = uris.from_fs_path(__file__)
-NOTEBOOK_URI = uris.from_fs_path('notebook_uri')
+NOTEBOOK_URI = uris.from_fs_path("notebook_uri")
 
 
 def path_as_uri(path):


### PR DESCRIPTION
This is a work-in-progress PR to add go to definition support on top of the notebook protocol developed in #389 by @tkrabel-db.

Likely each plugin, such as go to definition, will need to be modified to support the notebook syncing messages. We'll try to abstract out general patterns where possible, though.