### PR TITLE
Add support for pyflakes 3.1 and pycodestyle 2.11

### DIFF
--- a/pylsp/plugins/pyflakes_lint.py
+++ b/pylsp/plugins/pyflakes_lint.py
@@ -15,7 +15,6 @@ PYFLAKES_ERROR_MESSAGES = (
     messages.YieldOutsideFunction,
     messages.ContinueOutsideLoop,
     messages.BreakOutsideLoop,
-    messages.ContinueInFinally,
     messages.TwoStarredExpressions,
 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,22 +28,22 @@ Homepage = "https://github.com/python-lsp/python-lsp-server"
 [project.optional-dependencies]
 all = [
     "autopep8>=1.6.0,<2.1.0",
-    "flake8>=5.0.0,<7",
+    "flake8>=6.1.0,<7",
     "mccabe>=0.7.0,<0.8.0",
-    "pycodestyle>=2.9.0,<2.11.0",
+    "pycodestyle>=2.11.0,<2.12.0",
     "pydocstyle>=6.3.0,<6.4.0",
-    "pyflakes>=2.5.0,<3.1.0",
+    "pyflakes>=3.1.0,<3.2.0",
     "pylint>=2.5.0,<3",
     "rope>1.2.0",
     "yapf>=0.33.0",
     "whatthepatch>=1.0.2,<2.0.0"
 ]
 autopep8 = ["autopep8>=1.6.0,<2.1.0"]
-flake8 = ["flake8>=5.0.0,<7"]
+flake8 = ["flake8>=6.1.0,<7"]
 mccabe = ["mccabe>=0.7.0,<0.8.0"]
-pycodestyle = ["pycodestyle>=2.9.0,<2.11.0"]
+pycodestyle = ["pycodestyle>=2.11.0,<2.12.0"]
 pydocstyle = ["pydocstyle>=6.3.0,<6.4.0"]
-pyflakes = ["pyflakes>=2.5.0,<3.1.0"]
+pyflakes = ["pyflakes>=3.1.0,<3.2.0"]
 pylint = ["pylint>=2.5.0,<3"]
 rope = ["rope>1.2.0"]
 yapf = ["yapf>=0.33.0", "whatthepatch>=1.0.2,<2.0.0"]


### PR DESCRIPTION
`ContinueInFinally` is dropped in pyflakes 3.1 [1].

flake8 is bumped to a version that supports pyflakes 3.1 [2].

Closes https://github.com/python-lsp/python-lsp-server/issues/412

[1] https://github.com/PyCQA/pyflakes/pull/752
[2] https://flake8.pycqa.org/en/latest/release-notes/6.1.0.html