### PR TITLE
Bump Jedi upper pin to <0.20

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.7"
 dependencies = [
-    "jedi>=0.17.2,<0.19.0",
+    "jedi>=0.17.2,<0.20.0",
     "python-lsp-jsonrpc>=1.0.0",
     "pluggy>=1.0.0",
     "docstring-to-markdown",


### PR DESCRIPTION
There doesn't seem to be any breaking change in jedi 0.19

Closes #414 