### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           # TODO: check with Python 3, but need to fix the
           # errors first
-          python-version: '3.7'
+          python-version: '3.8'
           architecture: 'x64'
       - run: python -m pip install --upgrade pip setuptools jsonschema
       - run: pip install -e .[pylint,pycodestyle,pyflakes]

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.9', '3.8', '3.7']
+        PYTHON_VERSION: ['3.10', '3.9', '3.8']
     timeout-minutes: 10
     steps:
       - uses: actions/cache@v1

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.9', '3.8', '3.7']
+        PYTHON_VERSION: ['3.10', '3.9', '3.8']
     timeout-minutes: 10
     steps:
       - uses: actions/cache@v1

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.9', '3.8', '3.7']
+        PYTHON_VERSION: ['3.10', '3.9', '3.8']
     timeout-minutes: 10
     steps:
       - uses: actions/cache@v1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![image](https://github.com/python-ls/python-ls/workflows/Linux%20tests/badge.svg)](https://github.com/python-ls/python-ls/actions?query=workflow%3A%22Linux+tests%22) [![image](https://github.com/python-ls/python-ls/workflows/Mac%20tests/badge.svg)](https://github.com/python-ls/python-ls/actions?query=workflow%3A%22Mac+tests%22) [![image](https://github.com/python-ls/python-ls/workflows/Windows%20tests/badge.svg)](https://github.com/python-ls/python-ls/actions?query=workflow%3A%22Windows+tests%22) [![image](https://img.shields.io/github/license/python-ls/python-ls.svg)](https://github.com/python-ls/python-ls/blob/master/LICENSE)
 
-A Python 3.7+ implementation of the [Language Server Protocol](https://github.com/Microsoft/language-server-protocol).
+A Python 3.8+ implementation of the [Language Server Protocol](https://github.com/Microsoft/language-server-protocol).
 (Note: versions <1.4 should still work with Python 3.6)
 
 ## Installation
@@ -81,7 +81,7 @@ apk add py3-lsp-server
 
 Installing these plugins will add extra functionality to the language server:
 
-- [pylsp-mypy](https://github.com/Richardk2n/pylsp-mypy): [MyPy](http://mypy-lang.org/) type checking for Python >=3.7.
+- [pylsp-mypy](https://github.com/Richardk2n/pylsp-mypy): [MyPy](http://mypy-lang.org/) type checking for Python >=3.8.
 - [pyls-isort](https://github.com/paradoxxxzero/pyls-isort): code formatting using [isort](https://github.com/PyCQA/isort) (automatic import sorting).
 - [python-lsp-black](https://github.com/python-lsp/python-lsp-black): code formatting using [Black](https://github.com/psf/black).
 - [pyls-memestra](https://github.com/QuantStack/pyls-memestra): detecting the use of deprecated APIs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [{name = "Python Language Server Contributors"}]
 description = "Python Language Server for the Language Server Protocol"
 readme = "README.md"
 license = {text = "MIT"}
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
     "jedi>=0.17.2,<0.20.0",
     "python-lsp-jsonrpc>=1.0.0",


### PR DESCRIPTION
That version reached end-of-life at the end of June, so there's no need for us to keep supporting it.