### PR TITLE
Use invalid request handler rather than raising key error for requests after shutdown

### DIFF
--- a/pylsp/lsp.py
+++ b/pylsp/lsp.py
@@ -95,3 +95,21 @@ class TextDocumentSyncKind:
 class NotebookCellKind:
     Markup = 1
     Code = 2
+
+
+# https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#errorCodes
+class ErrorCodes:
+    ParseError = -32700
+    InvalidRequest = -32600
+    MethodNotFound = -32601
+    InvalidParams = -32602
+    InternalError = -32603
+    jsonrpcReservedErrorRangeStart = -32099
+    ServerNotInitialized = -32002
+    UnknownErrorCode = -32001
+    jsonrpcReservedErrorRangeEnd = -32000
+    lspReservedErrorRangeStart = -32899
+    ServerCancelled = -32802
+    ContentModified = -32801
+    RequestCancelled = -32800
+    lspReservedErrorRangeEnd = -32800

--- a/pylsp/python_lsp.py
+++ b/pylsp/python_lsp.py
@@ -238,7 +238,7 @@ class PythonLSPServer(MethodDispatcher):
         return {
             "error": {
                 "code": lsp.ErrorCodes.InvalidRequest,
-                "message": "Requests after shutdown not valid",
+                "message": "Requests after shutdown are not valid",
             }
         }
 

--- a/pylsp/python_lsp.py
+++ b/pylsp/python_lsp.py
@@ -215,7 +215,7 @@ class PythonLSPServer(MethodDispatcher):
         if self._shutdown and item != "exit":
             # exit is the only allowed method during shutdown
             log.debug("Ignoring non-exit method during shutdown: %s", item)
-            raise KeyError
+            item = "invalid_request_after_shutdown"
 
         try:
             return super().__getitem__(item)
@@ -233,6 +233,14 @@ class PythonLSPServer(MethodDispatcher):
         for workspace in self.workspaces.values():
             workspace.close()
         self._shutdown = True
+
+    def m_invalid_request_after_shutdown(self, **_kwargs):
+        return {
+            "error": {
+                "code": lsp.ErrorCodes.InvalidRequest,
+                "message": "Requests after shutdown not valid",
+            }
+        }
 
     def m_exit(self, **_kwargs):
         self._endpoint.shutdown()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "importlib_metadata>=4.8.3;python_version<\"3.10\"",
     "jedi>=0.17.2,<0.20.0",
     "pluggy>=1.0.0",
-    "python-lsp-jsonrpc>=1.0.0",
+    "python-lsp-jsonrpc>=1.1.0,<2.0.0",
     "ujson>=3.0.0",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
This is to fix https://github.com/python-lsp/python-lsp-server/issues/314 (for dealing with requests that come in after shutdown, e.g. from neovim). It requires https://github.com/python-lsp/python-lsp-jsonrpc/pull/20 to work properly, which probably means it shouldn't merge without first bumping the min required version of python-lsp-jsonrpc.

Fixes #314.