### PR TITLE
Fix null reference for syntax errors due to invalid encodings (Pyflakes)

### DIFF
--- a/pylsp/plugins/pyflakes_lint.py
+++ b/pylsp/plugins/pyflakes_lint.py
@@ -52,6 +52,9 @@ class PyflakesDiagnosticReport:
         # We've seen that lineno and offset can sometimes be None
         lineno = lineno or 1
         offset = offset or 0
+        # could be None if the error is due to an invalid encoding
+        # see e.g. https://github.com/python-lsp/python-lsp-server/issues/429
+        text = text or ""
 
         err_range = {
             "start": {"line": lineno - 1, "character": offset},


### PR DESCRIPTION
If the syntax error is due to an invalid encoding, `text` will be `None`, so we give it an empty string in this case. This fixes https://github.com/python-lsp/python-lsp-server/issues/429.

Fixes #429.