### PR TITLE
Don't set cwd in Popen kwargs when document root is empty (flake8)

### DIFF
--- a/pylsp/plugins/flake8_lint.py
+++ b/pylsp/plugins/flake8_lint.py
@@ -109,11 +109,14 @@ def run_flake8(flake8_executable, args, document):
         )
 
     log.debug("Calling %s with args: '%s'", flake8_executable, args)
+    popen_kwargs = {}
+    if cwd := document._workspace.root_path:
+        popen_kwargs["cwd"] = cwd
     try:
         cmd = [flake8_executable]
         cmd.extend(args)
         p = Popen(
-            cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, cwd=document._workspace.root_path
+            cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, **popen_kwargs
         )
     except IOError:
         log.debug(
@@ -124,7 +127,7 @@ def run_flake8(flake8_executable, args, document):
         cmd = [sys.executable, "-m", "flake8"]
         cmd.extend(args)
         p = Popen(  # pylint: disable=consider-using-with
-            cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, cwd=document._workspace.root_path
+            cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, **popen_kwargs
         )
     (stdout, stderr) = p.communicate(document.source.encode())
     if stderr:

--- a/pylsp/plugins/flake8_lint.py
+++ b/pylsp/plugins/flake8_lint.py
@@ -115,9 +115,7 @@ def run_flake8(flake8_executable, args, document):
     try:
         cmd = [flake8_executable]
         cmd.extend(args)
-        p = Popen(
-            cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, **popen_kwargs
-        )
+        p = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, **popen_kwargs)
     except IOError:
         log.debug(
             "Can't execute %s. Trying with '%s -m flake8'",


### PR DESCRIPTION
This PR implements the solution proposed in https://github.com/python-lsp/python-lsp-server/issues/406 to not set the `cwd` keyword argument in the flake8 process runner whenever the document root is empty. This helps prevent errors in windows, which apparently doesn't like an empty cwd.

Fixes #406.