### PR TITLE
Add black reformatting commit to `.git-blame-ignore-revs`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Reformatting with Black
+d47dc3c1fd1f2bafcc079006c3283e465b372f75


### PR DESCRIPTION
Follow-up to #407, quality of life improvement for when we need to look in the history. GitHub respects  `.git-blame-ignore-revs` since over a year now.

Reference: https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view