### PR TITLE
Fix `include_declaration` handling in references request

### DIFF
--- a/pylsp/plugins/references.py
+++ b/pylsp/plugins/references.py
@@ -8,7 +8,7 @@ log = logging.getLogger(__name__)
 
 
 @hookimpl
-def pylsp_references(document, position, exclude_declaration=False):
+def pylsp_references(document, position, exclude_declaration):
     code_position = _utils.position_to_jedi_linecolumn(document, position)
     usages = document.jedi_script().get_references(**code_position)
 

--- a/test/plugins/test_references.py
+++ b/test/plugins/test_references.py
@@ -42,7 +42,7 @@ def test_references(tmp_workspace):  # pylint: disable=redefined-outer-name
     DOC1_URI = uris.from_fs_path(os.path.join(tmp_workspace.root_path, DOC1_NAME))
     doc1 = Document(DOC1_URI, tmp_workspace)
 
-    refs = pylsp_references(doc1, position)
+    refs = pylsp_references(doc1, position, exclude_declaration=False)
 
     # Definition, the import and the instantiation
     assert len(refs) == 3
@@ -72,7 +72,7 @@ def test_references_builtin(tmp_workspace):  # pylint: disable=redefined-outer-n
     doc2_uri = uris.from_fs_path(os.path.join(str(tmp_workspace.root_path), DOC2_NAME))
     doc2 = Document(doc2_uri, tmp_workspace)
 
-    refs = pylsp_references(doc2, position)
+    refs = pylsp_references(doc2, position, exclude_declaration=False)
     assert len(refs) >= 1
 
     expected = {


### PR DESCRIPTION
Fixes #439. The recommendation not to use default values was confirmed by a pluggy maintainer: https://github.com/pytest-dev/pluggy/issues/442#issuecomment-1712843504.