### PR TITLE
Allow Jedi "goto" to perform multiple hops for "go to definition"

### DIFF
--- a/pylsp/plugins/definition.py
+++ b/pylsp/plugins/definition.py
@@ -14,10 +14,15 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
+MAX_JEDI_GOTO_HOPS = 100
+
+
 def _resolve_definition(
     maybe_defn: Name, script: Script, settings: Dict[str, Any]
 ) -> Name:
-    while not maybe_defn.is_definition() and maybe_defn.module_path == script.path:
+    for _ in range(MAX_JEDI_GOTO_HOPS):
+        if maybe_defn.is_definition() or maybe_defn.module_path != script.path:
+            break
         defns = script.goto(
             follow_imports=settings.get("follow_imports", True),
             follow_builtin_imports=settings.get("follow_builtin_imports", True),

--- a/test/plugins/test_definitions.py
+++ b/test/plugins/test_definitions.py
@@ -12,7 +12,7 @@ DOC_URI = uris.from_fs_path(__file__)
 DOC = """def a():
     pass
 
-print a()
+print(a())
 
 
 class Directory(object):
@@ -26,6 +26,16 @@ class Directory(object):
 subscripted_before_reference = {}
 subscripted_before_reference[0] = 0
 subscripted_before_reference
+
+
+def my_func():
+    print('called')
+
+alias = my_func
+my_list = [1, None, alias]
+inception = my_list[2]
+
+inception()
 """
 
 
@@ -49,10 +59,28 @@ def test_indirect_definitions(config, workspace):
     # Over 'subscripted_before_reference'
     cursor_pos = {"line": 16, "character": 0}
 
-    # The definition of 'subscripted_before_reference'
+    # The definition of 'subscripted_before_reference',
+    # skipping intermediate writes to the most recent definition
     def_range = {
         "start": {"line": 14, "character": 0},
         "end": {"line": 14, "character": len("subscripted_before_reference")},
+    }
+
+    doc = Document(DOC_URI, workspace, DOC)
+    assert [{"uri": DOC_URI, "range": def_range}] == pylsp_definitions(
+        config, doc, cursor_pos
+    )
+
+
+def test_definition_with_multihop_inference_goto(config, workspace):
+    # Over 'subscripted_before_reference'
+    cursor_pos = {"line": 26, "character": 0}
+
+    # The most recent definition of 'inception',
+    # ignoring alias hops
+    def_range = {
+        "start": {"line": 24, "character": 0},
+        "end": {"line": 24, "character": len("inception")},
     }
 
     doc = Document(DOC_URI, workspace, DOC)

--- a/test/plugins/test_definitions.py
+++ b/test/plugins/test_definitions.py
@@ -21,6 +21,11 @@ class Directory(object):
 
     def add_member(self, id, name):
         self.members[id] = name
+        
+        
+subscripted_before_reference = {}
+subscripted_before_reference[0] = 0
+subscripted_before_reference
 """
 
 
@@ -32,6 +37,22 @@ def test_definitions(config, workspace):
     def_range = {
         "start": {"line": 0, "character": 4},
         "end": {"line": 0, "character": 5},
+    }
+
+    doc = Document(DOC_URI, workspace, DOC)
+    assert [{"uri": DOC_URI, "range": def_range}] == pylsp_definitions(
+        config, doc, cursor_pos
+    )
+
+
+def test_indirect_definitions(config, workspace):
+    # Over 'subscripted_before_reference'
+    cursor_pos = {"line": 16, "character": 0}
+
+    # The definition of 'subscripted_before_reference'
+    def_range = {
+        "start": {"line": 14, "character": 0},
+        "end": {"line": 14, "character": len("subscripted_before_reference")},
     }
 
     doc = Document(DOC_URI, workspace, DOC)

--- a/test/plugins/test_definitions.py
+++ b/test/plugins/test_definitions.py
@@ -73,7 +73,7 @@ def test_indirect_definitions(config, workspace):
 
 
 def test_definition_with_multihop_inference_goto(config, workspace):
-    # Over 'subscripted_before_reference'
+    # Over 'inception()'
     cursor_pos = {"line": 26, "character": 0}
 
     # The most recent definition of 'inception',


### PR DESCRIPTION
The implementation of lsp definitions performs one hop of jedi "goto". This is inadequate for cases such as the following:
```python
d = {}
d[0]
d
```
A "definitions" request on the final reference to `d` will run a jedi goto that finds the reference to d in `d[0] = 0`, which then gets filtered out by the language server because it's not considered a definition. To fix, when we run a `goto` that finds something that's not a definition, keep running `goto`s on the thing we found until we either do find one, or exhaust the chain.

Added a unit test to cover this case, as well as type definitions to the definitions plugin.