### PR TITLE
Fix numpy go-to-definition by taking it off autoimport list for this case

### DIFF
--- a/pylsp/plugins/definition.py
+++ b/pylsp/plugins/definition.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 import logging
 from typing import Any, Dict, List, TYPE_CHECKING
+
+import jedi
+
 from pylsp import hookimpl, uris, _utils
 
 if TYPE_CHECKING:
@@ -43,12 +46,17 @@ def pylsp_definitions(
     settings = config.plugin_settings("jedi_definition")
     code_position = _utils.position_to_jedi_linecolumn(document, position)
     script = document.jedi_script(use_document_path=True)
-    definitions = script.goto(
-        follow_imports=settings.get("follow_imports", True),
-        follow_builtin_imports=settings.get("follow_builtin_imports", True),
-        **code_position,
-    )
-    definitions = [_resolve_definition(d, script, settings) for d in definitions]
+    auto_import_modules = jedi.settings.auto_import_modules
+    try:
+        jedi.settings.auto_import_modules = []
+        definitions = script.goto(
+            follow_imports=settings.get("follow_imports", True),
+            follow_builtin_imports=settings.get("follow_builtin_imports", True),
+            **code_position,
+        )
+        definitions = [_resolve_definition(d, script, settings) for d in definitions]
+    finally:
+        jedi.settings.auto_import_modules = auto_import_modules
     follow_builtin_defns = settings.get("follow_builtin_definitions", True)
     return [
         {

--- a/pylsp/plugins/definition.py
+++ b/pylsp/plugins/definition.py
@@ -47,6 +47,7 @@ def pylsp_definitions(
     code_position = _utils.position_to_jedi_linecolumn(document, position)
     script = document.jedi_script(use_document_path=True)
     auto_import_modules = jedi.settings.auto_import_modules
+
     try:
         jedi.settings.auto_import_modules = []
         definitions = script.goto(
@@ -57,6 +58,7 @@ def pylsp_definitions(
         definitions = [_resolve_definition(d, script, settings) for d in definitions]
     finally:
         jedi.settings.auto_import_modules = auto_import_modules
+
     follow_builtin_defns = settings.get("follow_builtin_definitions", True)
     return [
         {

--- a/test/plugins/test_definitions.py
+++ b/test/plugins/test_definitions.py
@@ -42,14 +42,6 @@ numpy.ones
 """
 
 
-def test_numpy(config, workspace):
-    cursor_pos = {"line": 29, "character": 8}
-
-    doc = Document(DOC_URI, workspace, DOC)
-    defns = pylsp_definitions(config, doc, cursor_pos)
-    assert len(defns) > 0, defns
-
-
 def test_definitions(config, workspace):
     # Over 'a' in print a
     cursor_pos = {"line": 3, "character": 6}
@@ -98,6 +90,15 @@ def test_definition_with_multihop_inference_goto(config, workspace):
     assert [{"uri": DOC_URI, "range": def_range}] == pylsp_definitions(
         config, doc, cursor_pos
     )
+
+
+def test_numpy_definition(config, workspace):
+    # Over numpy.ones
+    cursor_pos = {"line": 29, "character": 8}
+
+    doc = Document(DOC_URI, workspace, DOC)
+    defns = pylsp_definitions(config, doc, cursor_pos)
+    assert len(defns) > 0, defns
 
 
 def test_builtin_definition(config, workspace):

--- a/test/plugins/test_definitions.py
+++ b/test/plugins/test_definitions.py
@@ -36,7 +36,18 @@ my_list = [1, None, alias]
 inception = my_list[2]
 
 inception()
+
+import numpy
+numpy.ones
 """
+
+
+def test_numpy(config, workspace):
+    cursor_pos = {"line": 29, "character": 8}
+
+    doc = Document(DOC_URI, workspace, DOC)
+    defns = pylsp_definitions(config, doc, cursor_pos)
+    assert len(defns) > 0, defns
 
 
 def test_definitions(config, workspace):


### PR DESCRIPTION
When `numpy` is in the autoimport list, I think go to definition doesn't use the pure static strategy of jedi's `goto` and sees that, e.g., `numpy.ones` has `__module__` set to `numpy` and uses that, while the static strategy correctly sees that `ones` is defined in `numpy.core.numeric`. To fix, in this PR we take everything off the jedi autoimport list before using `goto` for GTD, and we restore it once we're done.

Test plan: added a unit test that passes with this PR and fails without this PR.