### PR TITLE
Improve hover results

### DIFF
--- a/pylsp/plugins/hover.py
+++ b/pylsp/plugins/hover.py
@@ -8,43 +8,81 @@ from pylsp import _utils, hookimpl
 log = logging.getLogger(__name__)
 
 
+def _find_docstring(definitions):
+    if len(definitions) != 1:
+        # Either no definitions or multiple definitions
+        # If we have multiple definitions the element can be multiple things and we
+        # do not know which one
+
+        # TODO(Review)
+        # We could also concatenate all docstrings we find in the definitions
+        # I am agains this because
+        # - If just one definition has a docstring, it gives a false impression of the hover element
+        # - If multiple definitions have a docstring, the user will probably not relize
+        #   that he can scroll to see the other options
+        return ""
+
+    # The single true definition
+    definition = definitions[0]
+    docstring = definition.docstring(
+        raw=True
+    )  # raw docstring returns only doc, without signature
+    if docstring != "":
+        return docstring
+
+    # If the definition has no docstring, try to infer the type
+    types = definition.infer()
+
+    if len(types) != 1:
+        # If we have multiple types the element can be multiple things and we
+        # do not know which one
+        return ""
+
+    # Use the docstring of the single true type (possibly empty)
+    return types[0].docstring(raw=True)
+
+
+def _find_signatures(definitions, word):
+    # Get the signatures of all definitions
+    signatures = [
+        signature.to_string()
+        for definition in definitions
+        for signature in definition.get_signatures()
+        if signature.type not in ["module"]
+    ]
+
+    if len(signatures) != 0:
+        return signatures
+
+    # If we did not find a signature, infer the possible types of all definitions
+    types = [
+        t.name
+        for d in sorted(definitions, key=lambda d: d.line)
+        for t in sorted(d.infer(), key=lambda t: t.line)
+    ]
+    if len(types) == 1:
+        return [types[0]]
+    elif len(types) > 1:
+        return [f"Union[{', '.join(types)}]"]
+
+
 @hookimpl
 def pylsp_hover(config, document, position):
     code_position = _utils.position_to_jedi_linecolumn(document, position)
-    definitions = document.jedi_script(use_document_path=True).infer(**code_position)
+
+    # TODO(Review)
+    # We could also use Script.help here. It would not resolve keywords
+    definitions = document.jedi_script(use_document_path=True).help(**code_position)
     word = document.word_at_position(position)
-
-    # Find first exact matching definition
-    definition = next((x for x in definitions if x.name == word), None)
-
-    # Ensure a definition is used if only one is available
-    # even if the word doesn't match. An example of this case is 'np'
-    # where 'numpy' doesn't match with 'np'. Same for NumPy ufuncs
-    if len(definitions) == 1:
-        definition = definitions[0]
-
-    if not definition:
-        return {"contents": ""}
 
     hover_capabilities = config.capabilities.get("textDocument", {}).get("hover", {})
     supported_markup_kinds = hover_capabilities.get("contentFormat", ["markdown"])
     preferred_markup_kind = _utils.choose_markup_kind(supported_markup_kinds)
 
-    # Find first exact matching signature
-    signature = next(
-        (
-            x.to_string()
-            for x in definition.get_signatures()
-            if (x.name == word and x.type not in ["module"])
-        ),
-        "",
-    )
-
     return {
         "contents": _utils.format_docstring(
-            # raw docstring returns only doc, without signature
-            definition.docstring(raw=True),
+            _find_docstring(definitions),
             preferred_markup_kind,
-            signatures=[signature] if signature else None,
+            signatures=_find_signatures(definitions, word),
         )
     }

--- a/pylsp/plugins/hover.py
+++ b/pylsp/plugins/hover.py
@@ -16,9 +16,9 @@ def _find_docstring(definitions):
 
         # TODO(Review)
         # We could also concatenate all docstrings we find in the definitions
-        # I am agains this because
+        # I am against this because
         # - If just one definition has a docstring, it gives a false impression of the hover element
-        # - If multiple definitions have a docstring, the user will probably not relize
+        # - If multiple definitions have a docstring, the user will probably not realize
         #   that he can scroll to see the other options
         return ""
 


### PR DESCRIPTION
This PR solves #444.

- Use jedi Script.help instead of infer - Ensures that docstrings of the definition are used if possible instead of docstrings of the type
- Show all possible signatures or types of the element hovered instead of just the first one that matches the name

I tried to describe the changes pretty well in the comments in the code. Note that there are two `TODO(Review)` comments that I would like feedback on.

Here are some examples of how the hover results change with this code change. The new results are highlighted with a green border.

![hover_preview_1](https://github.com/python-lsp/python-lsp-server/assets/6631116/49027efb-b0be-46af-ab0c-58da39b33605)
![hover_preview_2](https://github.com/python-lsp/python-lsp-server/assets/6631116/e033fddd-2e1b-4bad-a988-17c13eef5275)
![hover_preview_3](https://github.com/python-lsp/python-lsp-server/assets/6631116/faac06b7-9fef-4724-b1e7-07509dc52abe)
