### PR TITLE
Fix notebook document selector not being a list in capabilities

### DIFF
--- a/pylsp/python_lsp.py
+++ b/pylsp/python_lsp.py
@@ -295,7 +295,7 @@ class PythonLSPServer(MethodDispatcher):
                 "openClose": True,
             },
             "notebookDocumentSync": {
-                "notebookSelector": {"cells": [{"language": "python"}]}
+                "notebookSelector": [{"cells": [{"language": "python"}]}]
             },
             "workspace": {
                 "workspaceFolders": {"supported": True, "changeNotifications": True}

--- a/test/test_notebook_document.py
+++ b/test/test_notebook_document.py
@@ -33,7 +33,8 @@ def test_initialize(client_server_pair):
         },
     ).result(timeout=CALL_TIMEOUT_IN_SECONDS)
     assert server.workspace is not None
-    assert "notebookDocumentSync" in response["capabilities"].keys()
+    selector = response["capabilities"]["notebookDocumentSync"]["notebookSelector"]
+    assert isinstance(selector, list)
 
 
 @pytest.mark.skipif(IS_WIN, reason="Flaky on Windows")


### PR DESCRIPTION
In the LSP spec, `notebookSelector` in `NotebookDocumentSyncOptions` should be an array / list, not an object / dict. Note the `[]` at the end of the type in the spec: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#notebookDocumentSyncOptions

This PR fixes and adds a test.

Fixes #453