### PR TITLE
Load `rope_autoimport` cache on `workspace/didChangeConfiguration`

### DIFF
--- a/pylsp/hookspecs.py
+++ b/pylsp/hookspecs.py
@@ -127,3 +127,8 @@ def pylsp_settings(config):
 @hookspec(firstresult=True)
 def pylsp_signature_help(config, workspace, document, position):
     pass
+
+
+@hookspec
+def pylsp_workspace_configuration_changed(config, workspace):
+    pass

--- a/pylsp/plugins/rope_autoimport.py
+++ b/pylsp/plugins/rope_autoimport.py
@@ -238,3 +238,13 @@ def pylsp_document_did_open(config: Config, workspace: Workspace):
 def pylsp_document_did_save(config: Config, workspace: Workspace, document: Document):
     """Update the names associated with this document."""
     _reload_cache(config, workspace, [document])
+
+
+@hookimpl
+def pylsp_workspace_configuration_chaged(config: Config, workspace: Workspace):
+    """Initialize AutoImport if it has been enabled through a workspace/didChangeConfiguration message from the frontend.
+
+    Generates the cache for local and global items.
+    """
+    if config.plugin_settings("rope_autoimport").get("enabled", False):
+        _reload_cache(config, workspace)

--- a/pylsp/plugins/rope_autoimport.py
+++ b/pylsp/plugins/rope_autoimport.py
@@ -242,7 +242,8 @@ def pylsp_document_did_save(config: Config, workspace: Workspace, document: Docu
 
 @hookimpl
 def pylsp_workspace_configuration_chaged(config: Config, workspace: Workspace):
-    """Initialize AutoImport if it has been enabled through a workspace/didChangeConfiguration message from the frontend.
+    """Initialize AutoImport if it has been enabled through a
+    workspace/didChangeConfiguration message from the frontend.
 
     Generates the cache for local and global items.
     """

--- a/pylsp/plugins/rope_autoimport.py
+++ b/pylsp/plugins/rope_autoimport.py
@@ -242,7 +242,8 @@ def pylsp_document_did_save(config: Config, workspace: Workspace, document: Docu
 
 @hookimpl
 def pylsp_workspace_configuration_chaged(config: Config, workspace: Workspace):
-    """Initialize AutoImport if it has been enabled through a
+    """
+    Initialize autoimport if it has been enabled through a
     workspace/didChangeConfiguration message from the frontend.
 
     Generates the cache for local and global items.

--- a/pylsp/python_lsp.py
+++ b/pylsp/python_lsp.py
@@ -766,6 +766,7 @@ class PythonLSPServer(MethodDispatcher):
             self.config.update((settings or {}).get("pylsp", {}))
         for workspace in self.workspaces.values():
             workspace.update_config(settings)
+            self._hook("pylsp_workspace_configuration_changed")
             for doc_uri in workspace.documents:
                 self.lint(doc_uri, is_saved=False)
 


### PR DESCRIPTION
Fixes #460 

## How is this tested?

Manually, ensuring that autoimports works after sending a `workspace/didChangeConfiguration` to the backend.

<img width="538" alt="image" src="https://github.com/python-lsp/python-lsp-server/assets/91616041/43535daf-2d5b-48a1-b871-5381c66d5db8">
