### PR TITLE
Make workspace/didChangeConfig work with notebook documents

### DIFF
--- a/pylsp/plugins/rope_autoimport.py
+++ b/pylsp/plugins/rope_autoimport.py
@@ -205,6 +205,7 @@ def _reload_cache(
 ):
     memory: bool = config.plugin_settings("rope_autoimport").get("memory", False)
     rope_config = config.settings().get("rope", {})
+    log.debug("[_reload_cache] rope_config = %s", rope_config)
     autoimport = workspace._rope_autoimport(rope_config, memory)
     task_handle = PylspTaskHandle(workspace)
     resources: Optional[List[Resource]] = (
@@ -212,6 +213,7 @@ def _reload_cache(
         if files is None
         else [document._rope_resource(rope_config) for document in files]
     )
+    log.debug("[_reload_cache] resources = %s", resources)
     autoimport.generate_cache(task_handle=task_handle, resources=resources)
     autoimport.generate_modules_cache(task_handle=task_handle)
 
@@ -241,7 +243,7 @@ def pylsp_document_did_save(config: Config, workspace: Workspace, document: Docu
 
 
 @hookimpl
-def pylsp_workspace_configuration_chaged(config: Config, workspace: Workspace):
+def pylsp_workspace_configuration_changed(config: Config, workspace: Workspace):
     """
     Initialize autoimport if it has been enabled through a
     workspace/didChangeConfiguration message from the frontend.
@@ -250,3 +252,5 @@ def pylsp_workspace_configuration_chaged(config: Config, workspace: Workspace):
     """
     if config.plugin_settings("rope_autoimport").get("enabled", False):
         _reload_cache(config, workspace)
+    else:
+        log.debug("autoimport: Skipping cache reload.")

--- a/pylsp/plugins/rope_autoimport.py
+++ b/pylsp/plugins/rope_autoimport.py
@@ -205,7 +205,6 @@ def _reload_cache(
 ):
     memory: bool = config.plugin_settings("rope_autoimport").get("memory", False)
     rope_config = config.settings().get("rope", {})
-    log.debug("[_reload_cache] rope_config = %s", rope_config)
     autoimport = workspace._rope_autoimport(rope_config, memory)
     task_handle = PylspTaskHandle(workspace)
     resources: Optional[List[Resource]] = (
@@ -213,7 +212,6 @@ def _reload_cache(
         if files is None
         else [document._rope_resource(rope_config) for document in files]
     )
-    log.debug("[_reload_cache] resources = %s", resources)
     autoimport.generate_cache(task_handle=task_handle, resources=resources)
     autoimport.generate_modules_cache(task_handle=task_handle)
 

--- a/pylsp/plugins/rope_autoimport.py
+++ b/pylsp/plugins/rope_autoimport.py
@@ -241,7 +241,7 @@ def pylsp_document_did_save(config: Config, workspace: Workspace, document: Docu
 
 
 @hookimpl
-def pylsp_workspace_configuration_changed(config: Config, workspace: Workspace):
+def pylsp_workspace_configuration_chaged(config: Config, workspace: Workspace):
     """
     Initialize autoimport if it has been enabled through a
     workspace/didChangeConfiguration message from the frontend.
@@ -250,5 +250,3 @@ def pylsp_workspace_configuration_changed(config: Config, workspace: Workspace):
     """
     if config.plugin_settings("rope_autoimport").get("enabled", False):
         _reload_cache(config, workspace)
-    else:
-        log.debug("autoimport: Skipping cache reload.")

--- a/pylsp/workspace.py
+++ b/pylsp/workspace.py
@@ -78,10 +78,8 @@ class Workspace:
             rope_folder = rope_config.get("ropeFolder")
             if rope_folder:
                 self.__rope = Project(self._root_path, ropefolder=rope_folder)
-                log.debug("[_rope_project_builder] root_path = %s, ropenfolder = %s", self._root_path, rope_folder)
             else:
                 self.__rope = Project(self._root_path)
-                log.debug("[_rope_project_builder] root_path = %s, ropenfolder = '.ropeproject'", (self._root_path))
             self.__rope.prefs.set(
                 "extension_modules", rope_config.get("extensionModules", [])
             )

--- a/pylsp/workspace.py
+++ b/pylsp/workspace.py
@@ -78,8 +78,10 @@ class Workspace:
             rope_folder = rope_config.get("ropeFolder")
             if rope_folder:
                 self.__rope = Project(self._root_path, ropefolder=rope_folder)
+                log.debug("[_rope_project_builder] root_path = %s, ropenfolder = %s", self._root_path, rope_folder)
             else:
                 self.__rope = Project(self._root_path)
+                log.debug("[_rope_project_builder] root_path = %s, ropenfolder = '.ropeproject'", (self._root_path))
             self.__rope.prefs.set(
                 "extension_modules", rope_config.get("extensionModules", [])
             )

--- a/pylsp/workspace.py
+++ b/pylsp/workspace.py
@@ -169,7 +169,7 @@ class Workspace:
         for doc_uri in self.documents:
             if isinstance(document := self.get_document(doc_uri), Notebook):
                 # Notebook documents don't have a config. The config is
-                # handled on the cell level.
+                # handled at the cell level.
                 return
             document.update_config(settings)
 

--- a/pylsp/workspace.py
+++ b/pylsp/workspace.py
@@ -5,6 +5,7 @@ import io
 import logging
 from contextlib import contextmanager
 import os
+from pydoc import doc
 import re
 import uuid
 import functools
@@ -167,7 +168,11 @@ class Workspace:
     def update_config(self, settings):
         self._config.update((settings or {}).get("pylsp", {}))
         for doc_uri in self.documents:
-            self.get_document(doc_uri).update_config(settings)
+            if isinstance(document := self.get_document(doc_uri), Notebook):
+                # Notebook documents don't have a config. The config is
+                # handled on the cell level.
+                return
+            document.update_config(settings)
 
     def apply_edit(self, edit):
         return self._endpoint.request(self.M_APPLY_EDIT, {"edit": edit})

--- a/pylsp/workspace.py
+++ b/pylsp/workspace.py
@@ -5,7 +5,6 @@ import io
 import logging
 from contextlib import contextmanager
 import os
-from pydoc import doc
 import re
 import uuid
 import functools


### PR DESCRIPTION
## What change is proposed?

`Notebook` doesn't support `update_config`, as configuration is handled on the cell level. This makes `workspace/didChangeConfguration` error when there are notebook documents in the workspace. This PR fixes that.

## How is this tested?

- [x] unit test
- [x] Manually on Databricks notebooks, which supports notebookDocument messages