### PR TITLE
Ignore notebook names on cell completion for autoimport

### DIFF
--- a/pylsp/hookspecs.py
+++ b/pylsp/hookspecs.py
@@ -25,7 +25,7 @@ def pylsp_commands(config, workspace):
 
 
 @hookspec
-def pylsp_completions(config, workspace, document, position):
+def pylsp_completions(config, workspace, document, position, ignored_names):
     pass
 
 

--- a/pylsp/plugins/rope_autoimport.py
+++ b/pylsp/plugins/rope_autoimport.py
@@ -171,10 +171,8 @@ def pylsp_completions(
     ignored_names: Set[str] = ignored_names or get_names(
         document.jedi_script(use_document_path=True)
     )
-    log.debug("autoimport: ignored names: %s", ignored_names)
     autoimport = workspace._rope_autoimport(rope_config)
     suggestions = list(autoimport.search_full(word, ignored_names=ignored_names))
-    log.debug("autoimport: suggestions: %s", suggestions)
     results = list(
         sorted(
             _process_statements(suggestions, document.uri, word, autoimport, document),

--- a/pylsp/plugins/rope_autoimport.py
+++ b/pylsp/plugins/rope_autoimport.py
@@ -205,6 +205,7 @@ def _reload_cache(
 ):
     memory: bool = config.plugin_settings("rope_autoimport").get("memory", False)
     rope_config = config.settings().get("rope", {})
+    log.debug("[_reload_cache] rope_config = %s", rope_config)
     autoimport = workspace._rope_autoimport(rope_config, memory)
     task_handle = PylspTaskHandle(workspace)
     resources: Optional[List[Resource]] = (
@@ -212,6 +213,7 @@ def _reload_cache(
         if files is None
         else [document._rope_resource(rope_config) for document in files]
     )
+    log.debug("[_reload_cache] resources = %s", resources)
     autoimport.generate_cache(task_handle=task_handle, resources=resources)
     autoimport.generate_modules_cache(task_handle=task_handle)
 
@@ -241,7 +243,7 @@ def pylsp_document_did_save(config: Config, workspace: Workspace, document: Docu
 
 
 @hookimpl
-def pylsp_workspace_configuration_chaged(config: Config, workspace: Workspace):
+def pylsp_workspace_configuration_changed(config: Config, workspace: Workspace):
     """
     Initialize autoimport if it has been enabled through a
     workspace/didChangeConfiguration message from the frontend.
@@ -250,3 +252,5 @@ def pylsp_workspace_configuration_chaged(config: Config, workspace: Workspace):
     """
     if config.plugin_settings("rope_autoimport").get("enabled", False):
         _reload_cache(config, workspace)
+    else:
+        log.debug("autoimport: Skipping cache reload.")

--- a/pylsp/plugins/rope_autoimport.py
+++ b/pylsp/plugins/rope_autoimport.py
@@ -205,7 +205,6 @@ def _reload_cache(
 ):
     memory: bool = config.plugin_settings("rope_autoimport").get("memory", False)
     rope_config = config.settings().get("rope", {})
-    log.debug("[_reload_cache] rope_config = %s", rope_config)
     autoimport = workspace._rope_autoimport(rope_config, memory)
     task_handle = PylspTaskHandle(workspace)
     resources: Optional[List[Resource]] = (
@@ -213,7 +212,6 @@ def _reload_cache(
         if files is None
         else [document._rope_resource(rope_config) for document in files]
     )
-    log.debug("[_reload_cache] resources = %s", resources)
     autoimport.generate_cache(task_handle=task_handle, resources=resources)
     autoimport.generate_modules_cache(task_handle=task_handle)
 

--- a/pylsp/python_lsp.py
+++ b/pylsp/python_lsp.py
@@ -398,11 +398,9 @@ class PythonLSPServer(MethodDispatcher):
         document = workspace.get_document(doc_uri)
         ignored_names = None
         if isinstance(document, Cell):
-            log.debug("Getting ignored names from notebook document")
             # We need to get the ignored names from the whole notebook document
             notebook_document = workspace.get_maybe_document(document.notebook_uri)
             ignored_names = notebook_document.jedi_names()
-            log.debug("Got ignored names from notebook document: %s", ignored_names)
         completions = self._hook(
             "pylsp_completions", doc_uri, position=position, ignored_names=ignored_names
         )

--- a/pylsp/python_lsp.py
+++ b/pylsp/python_lsp.py
@@ -400,7 +400,7 @@ class PythonLSPServer(MethodDispatcher):
         if isinstance(document, Cell):
             # We need to get the ignored names from the whole notebook document
             notebook_document = workspace.get_maybe_document(document.notebook_uri)
-            ignored_names = notebook_document.jedi_names()
+            ignored_names = notebook_document.jedi_names(doc_uri)
         completions = self._hook(
             "pylsp_completions", doc_uri, position=position, ignored_names=ignored_names
         )

--- a/pylsp/workspace.py
+++ b/pylsp/workspace.py
@@ -78,10 +78,8 @@ class Workspace:
             rope_folder = rope_config.get("ropeFolder")
             if rope_folder:
                 self.__rope = Project(self._root_path, ropefolder=rope_folder)
-                log.debug("[_rope_project_builder] root_path = %s, ropenfolder = %s", self._root_path, rope_folder)
             else:
                 self.__rope = Project(self._root_path)
-                log.debug("[_rope_project_builder] root_path = %s, ropenfolder = '.ropeproject'", (self._root_path))
             self.__rope.prefs.set(
                 "extension_modules", rope_config.get("extensionModules", [])
             )

--- a/pylsp/workspace.py
+++ b/pylsp/workspace.py
@@ -78,8 +78,10 @@ class Workspace:
             rope_folder = rope_config.get("ropeFolder")
             if rope_folder:
                 self.__rope = Project(self._root_path, ropefolder=rope_folder)
+                log.debug("[_rope_project_builder] root_path = %s, ropenfolder = %s", self._root_path, rope_folder)
             else:
                 self.__rope = Project(self._root_path)
+                log.debug("[_rope_project_builder] root_path = %s, ropenfolder = '.ropeproject'", (self._root_path))
             self.__rope.prefs.set(
                 "extension_modules", rope_config.get("extensionModules", [])
             )

--- a/pylsp/workspace.py
+++ b/pylsp/workspace.py
@@ -627,12 +627,25 @@ class Notebook:
         return cell_data
 
     @lock
-    def jedi_names(self, all_scopes=False, definitions=True, references=False):
-        """Get all names to ignore from all cells."""
+    def jedi_names(
+        self,
+        up_to_cell_uri: Optional[str] = None,
+        all_scopes=False,
+        definitions=True,
+        references=False,
+    ):
+        """
+        Get the names in the notebook up to a certain cell.
+
+        :param up_to_cell_uri: The cell uri to stop at. If None, all cells are considered.
+        """
         names = set()
         for cell in self.cells:
-            cell_document = self.workspace.get_cell_document(cell["document"])
+            cell_uri = cell["document"]
+            cell_document = self.workspace.get_cell_document(cell_uri)
             names.update(cell_document.jedi_names(all_scopes, definitions, references))
+            if cell_uri == up_to_cell_uri:
+                break
         return set(name.name for name in names)
 
 

--- a/pylsp/workspace.py
+++ b/pylsp/workspace.py
@@ -637,7 +637,10 @@ class Notebook:
         """
         Get the names in the notebook up to a certain cell.
 
-        :param up_to_cell_uri: The cell uri to stop at. If None, all cells are considered.
+        Parameters
+        ----------
+        up_to_cell_uri: str, optional
+            The cell uri to stop at. If None, all cells are considered.
         """
         names = set()
         for cell in self.cells:

--- a/pylsp/workspace.py
+++ b/pylsp/workspace.py
@@ -5,6 +5,7 @@ import io
 import logging
 from contextlib import contextmanager
 import os
+from pydoc import doc
 import re
 import uuid
 import functools
@@ -167,7 +168,11 @@ class Workspace:
     def update_config(self, settings):
         self._config.update((settings or {}).get("pylsp", {}))
         for doc_uri in self.documents:
-            self.get_document(doc_uri).update_config(settings)
+            if isinstance(document := self.get_document(doc_uri), Notebook):
+                # Notebook documents don't have a config. The config is
+                # handled on the cell level.
+                return
+            document.update_config(settings)
 
     def apply_edit(self, edit):
         return self._endpoint.request(self.M_APPLY_EDIT, {"edit": edit})

--- a/pylsp/workspace.py
+++ b/pylsp/workspace.py
@@ -595,6 +595,7 @@ class Notebook:
         self.version = version
         self.cells = cells or []
         self.metadata = metadata or {}
+        self._lock = RLock()
 
     def __str__(self):
         return "Notebook with URI '%s'" % str(self.uri)
@@ -624,6 +625,15 @@ class Notebook:
             }
             offset += num_lines
         return cell_data
+
+    @lock
+    def jedi_names(self, all_scopes=False, definitions=True, references=False):
+        """Get all names to ignore from all cells."""
+        names = set()
+        for cell in self.cells:
+            cell_document = self.workspace.get_cell_document(cell["document"])
+            names.update(cell_document.jedi_names(all_scopes, definitions, references))
+        return set(name.name for name in names)
 
 
 class Cell(Document):

--- a/pylsp/workspace.py
+++ b/pylsp/workspace.py
@@ -5,7 +5,6 @@ import io
 import logging
 from contextlib import contextmanager
 import os
-from pydoc import doc
 import re
 import uuid
 import functools

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -6,9 +6,10 @@ from io import StringIO
 from unittest.mock import MagicMock
 
 from test.test_utils import ClientServerPair, CALL_TIMEOUT_IN_SECONDS
-import pylsp_jsonrpc
 
 import pytest
+import pylsp_jsonrpc
+
 from pylsp_jsonrpc.dispatchers import MethodDispatcher
 from pylsp_jsonrpc.endpoint import Endpoint
 from pylsp_jsonrpc.exceptions import JsonRpcException

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -5,7 +5,8 @@ import os
 from io import StringIO
 from unittest.mock import MagicMock
 
-from test.test_utils import ClientServerPair
+from test.test_utils import ClientServerPair, CALL_TIMEOUT_IN_SECONDS
+import pylsp_jsonrpc
 
 import pytest
 from pylsp_jsonrpc.dispatchers import MethodDispatcher
@@ -24,7 +25,6 @@ DOC = """import sys
 def main():
     print sys.stdin.read()
 """
-CALL_TIMEOUT_IN_SECONDS = 30
 
 
 class FakeEditorMethodsMixin:
@@ -175,8 +175,13 @@ def client_server_pair():
 
     yield (client_server_pair_obj.client, client_server_pair_obj.server)
 
-    shutdown_response = client_server_pair_obj.client._endpoint.request(
-        "shutdown"
-    ).result(timeout=CALL_TIMEOUT_IN_SECONDS)
-    assert shutdown_response is None
-    client_server_pair_obj.client._endpoint.notify("exit")
+    try:
+        shutdown_response = client_server_pair_obj.client._endpoint.request(
+            "shutdown"
+        ).result(timeout=CALL_TIMEOUT_IN_SECONDS)
+        assert shutdown_response is None
+        client_server_pair_obj.client._endpoint.notify("exit")
+    except pylsp_jsonrpc.exceptions.JsonRpcInvalidParams:
+        # SQLite objects created in a thread can only be used in that same thread.
+        # This exeception is raised when testing rope autoimport.
+        client_server_pair_obj.client._endpoint.notify("exit")

--- a/test/plugins/test_autoimport.py
+++ b/test/plugins/test_autoimport.py
@@ -232,7 +232,7 @@ def test_autoimport_for_notebook_document(
     assert rope_autoimport_settings.get("enabled", False) is True
     assert rope_autoimport_settings.get("memory", False) is True
 
-    suggestions = server.completions("cell_1_uri", {"line": 0, "character": 2}).get(
+    suggestions = server.completions("cell_2_uri", {"line": 0, "character": 2}).get(
         "items"
     )
     # We don't receive an autoimport suggestion for "os" because it's already imported
@@ -240,7 +240,7 @@ def test_autoimport_for_notebook_document(
         suggestion for suggestion in suggestions if suggestion.get("label", "") == "os"
     )
 
-    suggestions = server.completions("cell_2_uri", {"line": 0, "character": 3}).get(
+    suggestions = server.completions("cell_3_uri", {"line": 0, "character": 3}).get(
         "items"
     )
     # We receive an autoimport suggestion for "sys" because it's not already imported

--- a/test/plugins/test_autoimport.py
+++ b/test/plugins/test_autoimport.py
@@ -10,8 +10,7 @@ import jedi
 import parso
 import pytest
 
-from pylsp import IS_WIN, uris
-from pylsp import lsp
+from pylsp import IS_WIN, lsp, uris
 
 from pylsp.config.config import Config
 from pylsp.plugins.rope_autoimport import _get_score, _should_insert, get_names
@@ -236,6 +235,7 @@ def test_autoimport_for_notebook_document(
     suggestions = server.completions("cell_1_uri", {"line": 0, "character": 2}).get(
         "items"
     )
+    # We don't receive an autoimport suggestion for "os" because it's already imported
     assert not any(
         suggestion for suggestion in suggestions if suggestion.get("label", "") == "os"
     )
@@ -243,6 +243,7 @@ def test_autoimport_for_notebook_document(
     suggestions = server.completions("cell_2_uri", {"line": 0, "character": 3}).get(
         "items"
     )
+    # We receive an autoimport suggestion for "sys" because it's not already imported
     assert any(
         suggestion for suggestion in suggestions if suggestion.get("label", "") == "sys"
     )

--- a/test/plugins/test_autoimport.py
+++ b/test/plugins/test_autoimport.py
@@ -11,7 +11,6 @@ import parso
 import pytest
 
 from pylsp import IS_WIN, lsp, uris
-
 from pylsp.config.config import Config
 from pylsp.plugins.rope_autoimport import _get_score, _should_insert, get_names
 from pylsp.plugins.rope_autoimport import (

--- a/test/test_language_server.py
+++ b/test/test_language_server.py
@@ -5,7 +5,7 @@ import os
 import time
 import sys
 
-from test.test_utils import ClientServerPair
+from test.test_utils import ClientServerPair, send_initialize_request
 
 from flaky import flaky
 from pylsp_jsonrpc.exceptions import JsonRpcMethodNotFound
@@ -73,14 +73,7 @@ def test_not_exit_without_check_parent_process_flag(
     client_server_pair,
 ):
     client, _ = client_server_pair
-    response = client._endpoint.request(
-        "initialize",
-        {
-            "processId": 1234,
-            "rootPath": os.path.dirname(__file__),
-            "initializationOptions": {},
-        },
-    ).result(timeout=CALL_TIMEOUT_IN_SECONDS)
+    response = send_initialize_request(client)
     assert "capabilities" in response
 
 

--- a/test/test_notebook_document.py
+++ b/test/test_notebook_document.py
@@ -4,7 +4,7 @@ import os
 import time
 
 from unittest.mock import patch, call
-from test.fixtures import CALL_TIMEOUT_IN_SECONDS
+from test.test_utils import CALL_TIMEOUT_IN_SECONDS
 import pytest
 from pylsp.workspace import Notebook
 
@@ -29,7 +29,6 @@ def test_initialize(client_server_pair):
         {
             "processId": 1234,
             "rootPath": os.path.dirname(__file__),
-            "initializationOptions": {},
         },
     ).result(timeout=CALL_TIMEOUT_IN_SECONDS)
     assert server.workspace is not None
@@ -100,7 +99,6 @@ def test_notebook_document__did_open(
         {
             "processId": 1234,
             "rootPath": os.path.dirname(__file__),
-            "initializationOptions": {},
         },
     ).result(timeout=CALL_TIMEOUT_IN_SECONDS)
 
@@ -264,7 +262,6 @@ def test_notebook_document__did_change(
         {
             "processId": 1234,
             "rootPath": os.path.dirname(__file__),
-            "initializationOptions": {},
         },
     ).result(timeout=CALL_TIMEOUT_IN_SECONDS)
 
@@ -536,7 +533,6 @@ def test_notebook__did_close(
         {
             "processId": 1234,
             "rootPath": os.path.dirname(__file__),
-            "initializationOptions": {},
         },
     ).result(timeout=CALL_TIMEOUT_IN_SECONDS)
 
@@ -608,7 +604,6 @@ def test_notebook_definition(client_server_pair):
         {
             "processId": 1234,
             "rootPath": os.path.dirname(__file__),
-            "initializationOptions": {},
         },
     ).result(timeout=CALL_TIMEOUT_IN_SECONDS)
 

--- a/test/test_notebook_document.py
+++ b/test/test_notebook_document.py
@@ -1,10 +1,9 @@
 # Copyright 2021- Python Language Server Contributors.
 
 import time
-
 from unittest.mock import patch, call
-from test.fixtures import CALL_TIMEOUT_IN_SECONDS
-from test.test_utils import send_initialize_request, send_notebook_did_open
+
+from test.test_utils import CALL_TIMEOUT_IN_SECONDS, send_initialize_request, send_notebook_did_open
 
 import pytest
 from pylsp.workspace import Notebook

--- a/test/test_notebook_document.py
+++ b/test/test_notebook_document.py
@@ -3,7 +3,11 @@
 import time
 from unittest.mock import patch, call
 
-from test.test_utils import CALL_TIMEOUT_IN_SECONDS, send_initialize_request, send_notebook_did_open
+from test.test_utils import (
+    CALL_TIMEOUT_IN_SECONDS,
+    send_initialize_request,
+    send_notebook_did_open,
+)
 
 import pytest
 from pylsp.workspace import Notebook

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -25,7 +25,7 @@ def send_notebook_did_open(client, cells: List[str]):
     Sends a notebookDocument/didOpen notification with the given python cells.
 
     The notebook has the uri "notebook_uri" and the cells have the uris
-    "cell_0_uri", "cell_1_uri", etc.
+    "cell_1_uri", "cell_2_uri", etc.
     """
     client._endpoint.notify(
         "notebookDocument/didOpen", notebook_with_python_cells(cells)
@@ -37,7 +37,7 @@ def notebook_with_python_cells(cells: List[str]):
     Create a notebook document with the given python cells.
 
     The notebook has the uri "notebook_uri" and the cells have the uris
-    "cell_0_uri", "cell_1_uri", etc.
+    "cell_1_uri", "cell_2_uri", etc.
     """
     return {
         "notebookDocument": {
@@ -46,14 +46,14 @@ def notebook_with_python_cells(cells: List[str]):
             "cells": [
                 {
                     "kind": NotebookCellKind.Code,
-                    "document": f"cell_{i}_uri",
+                    "document": f"cell_{i+1}_uri",
                 }
                 for i in range(len(cells))
             ],
         },
         "cellTextDocuments": [
             {
-                "uri": f"cell_{i}_uri",
+                "uri": f"cell_{i+1}_uri",
                 "languageId": "python",
                 "text": cell,
             }
@@ -63,7 +63,7 @@ def notebook_with_python_cells(cells: List[str]):
 
 
 def send_initialize_request(client):
-    client._endpoint.request(
+    return client._endpoint.request(
         "initialize",
         {
             "processId": 1234,

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -6,13 +6,70 @@ import os
 import sys
 from threading import Thread
 import time
+from typing import List
 from unittest import mock
 
 from flaky import flaky
 from docstring_to_markdown import UnknownFormatError
+from build.lib.pylsp.lsp import NotebookCellKind
 
 from pylsp import _utils
 from pylsp.python_lsp import PythonLSPServer, start_io_lang_server
+
+
+CALL_TIMEOUT_IN_SECONDS = 30
+
+
+def send_notebook_did_open(client, cells: List[str]):
+    """
+    Sends a notebookDocument/didOpen notification with the given python cells.
+
+    The notebook has the uri "notebook_uri" and the cells have the uris
+    "cell_0_uri", "cell_1_uri", etc.
+    """
+    client._endpoint.notify(
+        "notebookDocument/didOpen", notebook_with_python_cells(cells)
+    )
+
+
+def notebook_with_python_cells(cells: List[str]):
+    """
+    Create a notebook document with the given python cells.
+
+    The notebook has the uri "notebook_uri" and the cells have the uris
+    "cell_0_uri", "cell_1_uri", etc.
+    """
+    return {
+        "notebookDocument": {
+            "uri": "notebook_uri",
+            "notebookType": "jupyter-notebook",
+            "cells": [
+                {
+                    "kind": NotebookCellKind.Code,
+                    "document": f"cell_{i}_uri",
+                }
+                for i in range(len(cells))
+            ],
+        },
+        "cellTextDocuments": [
+            {
+                "uri": f"cell_{i}_uri",
+                "languageId": "python",
+                "text": cell,
+            }
+            for i, cell in enumerate(cells)
+        ],
+    }
+
+
+def send_initialize_request(client):
+    client._endpoint.request(
+        "initialize",
+        {
+            "processId": 1234,
+            "rootPath": os.path.dirname(__file__),
+        },
+    ).result(timeout=CALL_TIMEOUT_IN_SECONDS)
 
 
 def start(obj):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -11,7 +11,7 @@ from unittest import mock
 
 from flaky import flaky
 from docstring_to_markdown import UnknownFormatError
-from build.lib.pylsp.lsp import NotebookCellKind
+from pylsp.lsp import NotebookCellKind
 
 from pylsp import _utils
 from pylsp.python_lsp import PythonLSPServer, start_io_lang_server

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -11,9 +11,9 @@ from unittest import mock
 
 from flaky import flaky
 from docstring_to_markdown import UnknownFormatError
-from pylsp.lsp import NotebookCellKind
 
 from pylsp import _utils
+from pylsp.lsp import NotebookCellKind
 from pylsp.python_lsp import PythonLSPServer, start_io_lang_server
 
 


### PR DESCRIPTION
## What is changed?

With the notebook document, every cell is its own document living in the workspace. When doing rope autoimport completions on a cell document position, we should not provide completion suggestions for names already imported before that (see video below).

## How is this tested?

- [x] integration test
- [x] manually on Databricks notebooks

https://github.com/python-lsp/python-lsp-server/assets/91616041/08965bd6-9921-41e2-b099-08e9d8244096

