### PR TITLE
Pass argument `extendIgnore` to flake8

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -8,6 +8,7 @@ This server can be configured using the `workspace/didChangeConfiguration` metho
 | `pylsp.plugins.flake8.config` | `string` | Path to the config file that will be the authoritative config source. | `null` |
 | `pylsp.plugins.flake8.enabled` | `boolean` | Enable or disable the plugin. | `false` |
 | `pylsp.plugins.flake8.exclude` | `array` of `string` items | List of files or directories to exclude. | `[]` |
+| `pylsp.plugins.flake8.extendIgnore` | `array` of `string` items | List of errors and warnings to append to ignore list. | `[]` |
 | `pylsp.plugins.flake8.executable` | `string` | Path to the flake8 executable. | `"flake8"` |
 | `pylsp.plugins.flake8.filename` | `string` | Only check for filenames matching the patterns in this list. | `null` |
 | `pylsp.plugins.flake8.hangClosing` | `boolean` | Hang closing bracket instead of matching indentation of opening bracket's line. | `null` |

--- a/pylsp/config/flake8_conf.py
+++ b/pylsp/config/flake8_conf.py
@@ -24,6 +24,7 @@ OPTIONS = [
     ("select", "plugins.pycodestyle.select", list),
     # flake8
     ("exclude", "plugins.flake8.exclude", list),
+    ("extend-ignore", "plugins.flake8.extendIgnore", list),
     ("filename", "plugins.flake8.filename", list),
     ("hang-closing", "plugins.flake8.hangClosing", bool),
     ("ignore", "plugins.flake8.ignore", list),

--- a/pylsp/config/schema.json
+++ b/pylsp/config/schema.json
@@ -37,6 +37,14 @@
       },
       "description": "List of files or directories to exclude."
     },
+    "pylsp.plugins.flake8.extendIgnore": {
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "string"
+      },
+      "description": "List of errors and warnings to append to ignore list."
+    },
     "pylsp.plugins.flake8.executable": {
       "type": "string",
       "default": "flake8",

--- a/pylsp/plugins/flake8_lint.py
+++ b/pylsp/plugins/flake8_lint.py
@@ -58,6 +58,7 @@ def pylsp_lint(workspace, document):
         opts = {
             "config": settings.get("config"),
             "exclude": settings.get("exclude"),
+            "extend-ignore": settings.get("extendIgnore"),
             "filename": settings.get("filename"),
             "hang-closing": settings.get("hangClosing"),
             "ignore": ignores or None,


### PR DESCRIPTION
As [black formatter documentation](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#line-length) recommends adding `extend-ignore="E203"` to flake8, it would be nice if we could be able to do this from lsp server options.