### PR TITLE
Raise supported Pylint upper version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ all = [
     "pycodestyle>=2.11.0,<2.12.0",
     "pydocstyle>=6.3.0,<6.4.0",
     "pyflakes>=3.1.0,<3.2.0",
-    "pylint>=2.5.0,<3",
+    "pylint>=2.5.0,<3.1",
     "rope>1.2.0",
     "yapf>=0.33.0",
     "whatthepatch>=1.0.2,<2.0.0"
@@ -44,12 +44,12 @@ mccabe = ["mccabe>=0.7.0,<0.8.0"]
 pycodestyle = ["pycodestyle>=2.11.0,<2.12.0"]
 pydocstyle = ["pydocstyle>=6.3.0,<6.4.0"]
 pyflakes = ["pyflakes>=3.1.0,<3.2.0"]
-pylint = ["pylint>=2.5.0,<3"]
+pylint = ["pylint>=2.5.0,<3.1"]
 rope = ["rope>1.2.0"]
 yapf = ["yapf>=0.33.0", "whatthepatch>=1.0.2,<2.0.0"]
 websockets = ["websockets>=10.3"]
 test = [
-    "pylint>=2.5.0,<3",
+    "pylint>=2.5.0,<3.1",
     "pytest",
     "pytest-cov",
     "coverage",


### PR DESCRIPTION
Pylint 3.0 is out but should not harm us here.