### PR TITLE
Make autoimport cache generation non-blocking

### DIFF
--- a/pylsp/_utils.py
+++ b/pylsp/_utils.py
@@ -8,10 +8,9 @@ import os
 import pathlib
 import re
 import threading
+import time
 from typing import List, Optional
 
-import time
-from functools import wraps
 import docstring_to_markdown
 import jedi
 
@@ -61,7 +60,7 @@ def throttle(seconds=1):
     """Throttles calls to a function evey `seconds` seconds."""
 
     def decorator(func):
-        @wraps(func)
+        @functools.wraps(func)
         def wrapper(*args, **kwargs):  # pylint: disable=inconsistent-return-statements
             if not hasattr(wrapper, "last_call"):
                 wrapper.last_call = 0

--- a/pylsp/_utils.py
+++ b/pylsp/_utils.py
@@ -59,6 +59,7 @@ def debounce(interval_s, keyed_by=None):
 
 def throttle(seconds=1):
     """Throttles calls to a function evey `seconds` seconds."""
+
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):  # pylint: disable=inconsistent-return-statements

--- a/pylsp/_utils.py
+++ b/pylsp/_utils.py
@@ -10,10 +10,10 @@ import re
 import threading
 from typing import List, Optional
 
-import docstring_to_markdown
-import jedi
 import time
 from functools import wraps
+import docstring_to_markdown
+import jedi
 
 JEDI_VERSION = jedi.__version__
 

--- a/pylsp/_utils.py
+++ b/pylsp/_utils.py
@@ -12,6 +12,8 @@ from typing import List, Optional
 
 import docstring_to_markdown
 import jedi
+import time
+from functools import wraps
 
 JEDI_VERSION = jedi.__version__
 
@@ -53,6 +55,22 @@ def debounce(interval_s, keyed_by=None):
         return debounced
 
     return wrapper
+
+
+def throttle(seconds=1):
+    """Throttles calls to a function evey `seconds` seconds."""
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):  # pylint: disable=inconsistent-return-statements
+            if not hasattr(wrapper, "last_call"):
+                wrapper.last_call = 0
+            if time.time() - wrapper.last_call >= seconds:
+                wrapper.last_call = time.time()
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
 
 
 def find_parents(root, path, names):

--- a/pylsp/plugins/_rope_task_handle.py
+++ b/pylsp/plugins/_rope_task_handle.py
@@ -1,32 +1,16 @@
 from __future__ import annotations
 
 import logging
-import time
-from functools import wraps
 
 from typing import Callable, ContextManager, List, Optional, Sequence
 
 from rope.base.taskhandle import BaseJobSet, BaseTaskHandle
 
 from pylsp.workspace import Workspace
+from pylsp._utils import throttle
 
 log = logging.getLogger(__name__)
 Report = Callable[[str, int], None]
-
-
-def throttle(seconds=1):
-    def decorator(func):
-        @wraps(func)
-        def wrapper(*args, **kwargs):  # pylint: disable=inconsistent-return-statements
-            if not hasattr(wrapper, "last_call"):
-                wrapper.last_call = 0
-            if time.time() - wrapper.last_call >= seconds:
-                wrapper.last_call = time.time()
-                return func(*args, **kwargs)
-
-        return wrapper
-
-    return decorator
 
 
 class PylspJobSet(BaseJobSet):

--- a/pylsp/plugins/_rope_task_handle.py
+++ b/pylsp/plugins/_rope_task_handle.py
@@ -17,7 +17,7 @@ Report = Callable[[str, int], None]
 def throttle(seconds=1):
     def decorator(func):
         @wraps(func)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args, **kwargs):  # pylint: disable=inconsistent-return-statements
             if not hasattr(wrapper, "last_call"):
                 wrapper.last_call = 0
             if time.time() - wrapper.last_call >= seconds:

--- a/pylsp/plugins/rope_autoimport.py
+++ b/pylsp/plugins/rope_autoimport.py
@@ -27,6 +27,8 @@ MAX_RESULTS_CODE_ACTIONS = 5
 
 
 class AutoimportCache:
+    """Handles the cache creation."""
+
     def __init__(self):
         self.thread = None
 
@@ -47,6 +49,8 @@ class AutoimportCache:
             if files is None
             else [document._rope_resource(rope_config) for document in files]
         )
+        # Creating the cache may take 10-20s for a environment with 5k python modules. That's
+        # why we decided to move cache creation into its own thread.
         self.thread = threading.Thread(
             target=self._reload_cache, args=(workspace, autoimport, resources)
         )

--- a/pylsp/plugins/rope_autoimport.py
+++ b/pylsp/plugins/rope_autoimport.py
@@ -72,7 +72,7 @@ class AutoimportCache:
         autoimport.generate_modules_cache(task_handle=task_handle)
 
     def is_blocked(self):
-        return cache.thread and cache.thread.is_alive()
+        return self.thread and self.thread.is_alive()
 
 
 @hookimpl

--- a/pylsp/python_lsp.py
+++ b/pylsp/python_lsp.py
@@ -163,7 +163,6 @@ class PythonLSPServer(MethodDispatcher):
     """Implementation of the Microsoft VSCode Language Server Protocol
     https://github.com/Microsoft/language-server-protocol/blob/master/versions/protocol-1-x.md
     """
-
     # pylint: disable=too-many-public-methods,redefined-builtin
 
     def __init__(
@@ -348,6 +347,7 @@ class PythonLSPServer(MethodDispatcher):
                 )
                 workspace_config.update(self.config._settings)
                 self.workspaces[uri] = Workspace(uri, self._endpoint, workspace_config)
+
 
         self._dispatchers = self._hook("pylsp_dispatchers")
         self._hook("pylsp_initialize")

--- a/pylsp/python_lsp.py
+++ b/pylsp/python_lsp.py
@@ -163,6 +163,7 @@ class PythonLSPServer(MethodDispatcher):
     """Implementation of the Microsoft VSCode Language Server Protocol
     https://github.com/Microsoft/language-server-protocol/blob/master/versions/protocol-1-x.md
     """
+
     # pylint: disable=too-many-public-methods,redefined-builtin
 
     def __init__(
@@ -347,7 +348,6 @@ class PythonLSPServer(MethodDispatcher):
                 )
                 workspace_config.update(self.config._settings)
                 self.workspaces[uri] = Workspace(uri, self._endpoint, workspace_config)
-
 
         self._dispatchers = self._hook("pylsp_dispatchers")
         self._hook("pylsp_initialize")

--- a/test/plugins/test_autoimport.py
+++ b/test/plugins/test_autoimport.py
@@ -15,6 +15,7 @@ from pylsp.config.config import Config
 from pylsp.plugins.rope_autoimport import (
     _get_score,
     _should_insert,
+    cache,
     get_name_or_module,
     get_names,
 )
@@ -58,6 +59,7 @@ def autoimport_workspace(tmp_path_factory) -> Workspace:
         }
     )
     pylsp_initialize(workspace._config, workspace)
+    wait_for_condition(lambda: not cache.thread.is_alive())
     yield workspace
     workspace.close()
 
@@ -293,6 +295,7 @@ def test_autoimport_code_actions_and_completions_for_notebook_document(
             }
         },
     )
+    from time import sleep
 
     with patch.object(server._endpoint, "notify") as mock_notify:
         # Expectations:
@@ -312,6 +315,7 @@ def test_autoimport_code_actions_and_completions_for_notebook_document(
     )
     assert rope_autoimport_settings.get("completions", {}).get("enabled", False) is True
     assert rope_autoimport_settings.get("memory", False) is True
+    wait_for_condition(lambda: not cache.thread.is_alive())
 
     # 1.
     quick_fixes = server.code_actions("cell_1_uri", {}, make_context("os", 0, 0, 2))

--- a/test/plugins/test_autoimport.py
+++ b/test/plugins/test_autoimport.py
@@ -295,8 +295,6 @@ def test_autoimport_code_actions_and_completions_for_notebook_document(
             }
         },
     )
-    from time import sleep
-
     with patch.object(server._endpoint, "notify") as mock_notify:
         # Expectations:
         # 1. We receive an autoimport suggestion for "os" in the first cell because
@@ -308,7 +306,9 @@ def test_autoimport_code_actions_and_completions_for_notebook_document(
         # 4. We receive an autoimport suggestion for "sys" because it's not already imported.
         # 5. If diagnostics doesn't contain "undefined name ...", we send empty quick fix suggestions.
         send_notebook_did_open(client, ["os", "import os\nos", "os", "sys"])
-        wait_for_condition(lambda: mock_notify.call_count >= 3)
+        wait_for_condition(lambda: mock_notify.call_count >= 4)
+        # We received diagnostics messages for every cell
+        assert all('textDocument/publishDiagnostics' in c.args for c in mock_notify.call_args_list)
 
     rope_autoimport_settings = server.workspace._config.plugin_settings(
         "rope_autoimport"

--- a/test/plugins/test_autoimport.py
+++ b/test/plugins/test_autoimport.py
@@ -308,7 +308,10 @@ def test_autoimport_code_actions_and_completions_for_notebook_document(
         send_notebook_did_open(client, ["os", "import os\nos", "os", "sys"])
         wait_for_condition(lambda: mock_notify.call_count >= 4)
         # We received diagnostics messages for every cell
-        assert all('textDocument/publishDiagnostics' in c.args for c in mock_notify.call_args_list)
+        assert all(
+            "textDocument/publishDiagnostics" in c.args
+            for c in mock_notify.call_args_list
+        )
 
     rope_autoimport_settings = server.workspace._config.plugin_settings(
         "rope_autoimport"

--- a/test/plugins/test_autoimport.py
+++ b/test/plugins/test_autoimport.py
@@ -22,7 +22,6 @@ from pylsp.plugins.rope_autoimport import (
 from pylsp.plugins.rope_autoimport import (
     pylsp_completions as pylsp_autoimport_completions,
 )
-from pylsp.plugins.rope_autoimport import pylsp_initialize
 from pylsp.workspace import Workspace
 
 

--- a/test/plugins/test_autoimport.py
+++ b/test/plugins/test_autoimport.py
@@ -58,8 +58,7 @@ def autoimport_workspace(tmp_path_factory) -> Workspace:
             }
         }
     )
-    pylsp_initialize(workspace._config, workspace)
-    wait_for_condition(lambda: not cache.thread.is_alive())
+    cache.reload_cache(workspace._config, workspace, single_thread=True)
     yield workspace
     workspace.close()
 


### PR DESCRIPTION
On a medium-sized virtual environment, rope takes 10-20 sec to create the module cache. During this time, the language server is unresponsive.

This is not a problem on a local machine where the cache is unlikely emptied, but poses a challenge in cloud environments such as Databricks, where the server runs on a cloud VM which gets pre-emptied regularly.

This PR makes cache initialization non-blocking, hence making the server response immediately after receiving an initialized message.

## How is this tested?

- [x] unit tests
- [x] e2e tests - making sure that the LSP server becomes responsive immediately, and rope working after the cache is created.