### PR TITLE
Introduce isort to check import order

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -39,9 +39,11 @@ jobs:
       # This error cannot be resolved by adding a pylint: disable=unused-argument comment ...
       - run: |
           pip install -e .[pylint,pycodestyle,pyflakes]
-          pip install black
+          pip install isort black
       - name: Pylint checks
         run: pylint pylsp test
+      - name: Check import order with isort
+        run: isort --check --profile black pylsp test
       - name: Code style checks with black
         run: black --check pylsp test
       - name: Pyflakes checks

--- a/README.md
+++ b/README.md
@@ -185,6 +185,14 @@ To run the test suite:
 pytest
 ```
 
+To run black and isort on the code base:
+
+```sh
+pip install isort black
+black pylsp test
+isort pylsp test  # runs automatically isort with --profile black
+```
+
 After adding configuration options to `schema.json`, refresh the `CONFIGURATION.md` file with
 
 ```

--- a/pylsp/__init__.py
+++ b/pylsp/__init__.py
@@ -2,7 +2,9 @@
 # Copyright 2021- Python Language Server Contributors.
 
 import os
+
 import pluggy
+
 from . import _version
 from ._version import __version__
 

--- a/pylsp/__main__.py
+++ b/pylsp/__main__.py
@@ -12,13 +12,13 @@ try:
 except Exception:  # pylint: disable=broad-except
     import json
 
+from ._version import __version__
 from .python_lsp import (
     PythonLSPServer,
     start_io_lang_server,
     start_tcp_lang_server,
     start_ws_lang_server,
 )
-from ._version import __version__
 
 LOG_FORMAT = "%(asctime)s {0} - %(levelname)s - %(name)s - %(message)s".format(
     time.localtime().tm_zone

--- a/pylsp/config/config.py
+++ b/pylsp/config/config.py
@@ -10,7 +10,7 @@ from typing import List, Mapping, Sequence, Union
 import pluggy
 from pluggy._hooks import HookImpl
 
-from pylsp import _utils, hookspecs, uris, PYLSP
+from pylsp import PYLSP, _utils, hookspecs, uris
 
 # See compatibility note on `group` keyword:
 #   https://docs.python.org/3/library/importlib.metadata.html#entry-points

--- a/pylsp/config/flake8_conf.py
+++ b/pylsp/config/flake8_conf.py
@@ -3,7 +3,9 @@
 
 import logging
 import os
+
 from pylsp._utils import find_parents
+
 from .source import ConfigSource
 
 log = logging.getLogger(__name__)

--- a/pylsp/config/pycodestyle_conf.py
+++ b/pylsp/config/pycodestyle_conf.py
@@ -2,9 +2,10 @@
 # Copyright 2021- Python Language Server Contributors.
 
 import pycodestyle
-from pylsp._utils import find_parents
-from .source import ConfigSource
 
+from pylsp._utils import find_parents
+
+from .source import ConfigSource
 
 CONFIG_KEY = "pycodestyle"
 USER_CONFIGS = [pycodestyle.USER_CONFIG] if pycodestyle.USER_CONFIG else []

--- a/pylsp/plugins/_resolvers.py
+++ b/pylsp/plugins/_resolvers.py
@@ -1,14 +1,13 @@
 # Copyright 2017-2020 Palantir Technologies, Inc.
 # Copyright 2021- Python Language Server Contributors.
 
-from collections import defaultdict
 import logging
+from collections import defaultdict
 from time import time
 
 from jedi.api.classes import Completion
 
 from pylsp import lsp
-
 
 log = logging.getLogger(__name__)
 

--- a/pylsp/plugins/_rope_task_handle.py
+++ b/pylsp/plugins/_rope_task_handle.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 import logging
-
 from typing import Callable, ContextManager, List, Optional, Sequence
 
 from rope.base.taskhandle import BaseJobSet, BaseTaskHandle
 
-from pylsp.workspace import Workspace
 from pylsp._utils import throttle
+from pylsp.workspace import Workspace
 
 log = logging.getLogger(__name__)
 Report = Callable[[str, int], None]

--- a/pylsp/plugins/autopep8_format.py
+++ b/pylsp/plugins/autopep8_format.py
@@ -4,7 +4,8 @@
 import logging
 
 import pycodestyle
-from autopep8 import fix_code, continued_indentation as autopep8_c_i
+from autopep8 import continued_indentation as autopep8_c_i
+from autopep8 import fix_code
 
 from pylsp import hookimpl
 from pylsp._utils import get_eol_chars

--- a/pylsp/plugins/definition.py
+++ b/pylsp/plugins/definition.py
@@ -1,16 +1,18 @@
 # Copyright 2017-2020 Palantir Technologies, Inc.
 # Copyright 2021- Python Language Server Contributors.
 from __future__ import annotations
+
 import logging
-from typing import Any, Dict, List, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, List
 
 import jedi
 
-from pylsp import hookimpl, uris, _utils
+from pylsp import _utils, hookimpl, uris
 
 if TYPE_CHECKING:
     from jedi.api import Script
     from jedi.api.classes import Name
+
     from pylsp.config.config import Config
     from pylsp.workspace import Document
 

--- a/pylsp/plugins/highlight.py
+++ b/pylsp/plugins/highlight.py
@@ -2,7 +2,8 @@
 # Copyright 2021- Python Language Server Contributors.
 
 import logging
-from pylsp import hookimpl, lsp, _utils
+
+from pylsp import _utils, hookimpl, lsp
 
 log = logging.getLogger(__name__)
 

--- a/pylsp/plugins/hover.py
+++ b/pylsp/plugins/hover.py
@@ -3,7 +3,7 @@
 
 import logging
 
-from pylsp import hookimpl, _utils
+from pylsp import _utils, hookimpl
 
 log = logging.getLogger(__name__)
 

--- a/pylsp/plugins/jedi_rename.py
+++ b/pylsp/plugins/jedi_rename.py
@@ -3,7 +3,7 @@
 
 import logging
 
-from pylsp import hookimpl, uris, _utils
+from pylsp import _utils, hookimpl, uris
 
 log = logging.getLogger(__name__)
 

--- a/pylsp/plugins/mccabe_lint.py
+++ b/pylsp/plugins/mccabe_lint.py
@@ -3,7 +3,9 @@
 
 import ast
 import logging
+
 import mccabe
+
 from pylsp import hookimpl, lsp
 
 log = logging.getLogger(__name__)

--- a/pylsp/plugins/preload_imports.py
+++ b/pylsp/plugins/preload_imports.py
@@ -2,6 +2,7 @@
 # Copyright 2021- Python Language Server Contributors.
 
 import logging
+
 from pylsp import hookimpl
 
 log = logging.getLogger(__name__)

--- a/pylsp/plugins/pydocstyle_lint.py
+++ b/pylsp/plugins/pydocstyle_lint.py
@@ -8,6 +8,7 @@ import re
 import sys
 
 import pydocstyle
+
 from pylsp import hookimpl, lsp
 
 log = logging.getLogger(__name__)

--- a/pylsp/plugins/pyflakes_lint.py
+++ b/pylsp/plugins/pyflakes_lint.py
@@ -1,7 +1,9 @@
 # Copyright 2017-2020 Palantir Technologies, Inc.
 # Copyright 2021- Python Language Server Contributors.
 
-from pyflakes import api as pyflakes_api, messages
+from pyflakes import api as pyflakes_api
+from pyflakes import messages
+
 from pylsp import hookimpl, lsp
 
 # Pyflakes messages that should be reported as Errors instead of Warns

--- a/pylsp/plugins/pylint_lint.py
+++ b/pylsp/plugins/pylint_lint.py
@@ -5,11 +5,11 @@
 """Linter plugin for pylint."""
 import collections
 import logging
-import sys
-import re
-from subprocess import Popen, PIPE
 import os
+import re
 import shlex
+import sys
+from subprocess import PIPE, Popen
 
 from pylsp import hookimpl, lsp
 

--- a/pylsp/plugins/references.py
+++ b/pylsp/plugins/references.py
@@ -2,7 +2,8 @@
 # Copyright 2021- Python Language Server Contributors.
 
 import logging
-from pylsp import hookimpl, uris, _utils
+
+from pylsp import _utils, hookimpl, uris
 
 log = logging.getLogger(__name__)
 

--- a/pylsp/plugins/rope_autoimport.py
+++ b/pylsp/plugins/rope_autoimport.py
@@ -1,8 +1,8 @@
 # Copyright 2022- Python Language Server Contributors.
 
 import logging
-from typing import Any, Dict, Generator, List, Optional, Set, Union
 import threading
+from typing import Any, Dict, Generator, List, Optional, Set, Union
 
 import parso
 from jedi import Script

--- a/pylsp/plugins/rope_completion.py
+++ b/pylsp/plugins/rope_completion.py
@@ -2,10 +2,10 @@
 # Copyright 2021- Python Language Server Contributors.
 
 import logging
+
 from rope.contrib.codeassist import code_assist, sorted_proposals
 
 from pylsp import _utils, hookimpl, lsp
-
 
 log = logging.getLogger(__name__)
 

--- a/pylsp/plugins/rope_rename.py
+++ b/pylsp/plugins/rope_rename.py
@@ -6,7 +6,7 @@ import logging
 from rope.base import libutils
 from rope.refactor.rename import Rename
 
-from pylsp import hookimpl, uris, _utils
+from pylsp import _utils, hookimpl, uris
 
 log = logging.getLogger(__name__)
 

--- a/pylsp/plugins/signature.py
+++ b/pylsp/plugins/signature.py
@@ -3,7 +3,8 @@
 
 import logging
 import re
-from pylsp import hookimpl, _utils
+
+from pylsp import _utils, hookimpl
 
 log = logging.getLogger(__name__)
 

--- a/pylsp/plugins/yapf_format.py
+++ b/pylsp/plugins/yapf_format.py
@@ -4,10 +4,9 @@
 import logging
 import os
 
+import whatthepatch
 from yapf.yapflib import file_resources, style
 from yapf.yapflib.yapf_api import FormatCode
-
-import whatthepatch
 
 from pylsp import hookimpl
 from pylsp._utils import get_eol_chars

--- a/pylsp/python_lsp.py
+++ b/pylsp/python_lsp.py
@@ -1,23 +1,23 @@
 # Copyright 2017-2020 Palantir Technologies, Inc.
 # Copyright 2021- Python Language Server Contributors.
 
-from functools import partial
 import logging
 import os
 import socketserver
 import threading
 import uuid
-from typing import List, Dict, Any
-import ujson as json
+from functools import partial
+from typing import Any, Dict, List
 
+import ujson as json
 from pylsp_jsonrpc.dispatchers import MethodDispatcher
 from pylsp_jsonrpc.endpoint import Endpoint
 from pylsp_jsonrpc.streams import JsonRpcStreamReader, JsonRpcStreamWriter
 
-from . import lsp, _utils, uris
-from .config import config
-from .workspace import Workspace, Document, Notebook, Cell
+from . import _utils, lsp, uris
 from ._version import __version__
+from .config import config
+from .workspace import Cell, Document, Notebook, Workspace
 
 log = logging.getLogger(__name__)
 
@@ -109,6 +109,7 @@ def start_ws_lang_server(port, check_parent_process, handler_class):
     try:
         import asyncio
         from concurrent.futures import ThreadPoolExecutor
+
         import websockets
     except ImportError as e:
         raise ImportError(

--- a/pylsp/uris.py
+++ b/pylsp/uris.py
@@ -7,6 +7,7 @@ https://github.com/Microsoft/vscode-uri/blob/e59cab84f5df6265aed18ae5f43552d3eef
 """
 import re
 from urllib import parse
+
 from pylsp import IS_WIN
 
 RE_DRIVE_LETTER_PATH = re.compile(r"^\/[a-zA-Z]:")

--- a/pylsp/workspace.py
+++ b/pylsp/workspace.py
@@ -1,19 +1,19 @@
 # Copyright 2017-2020 Palantir Technologies, Inc.
 # Copyright 2021- Python Language Server Contributors.
 
+import functools
 import io
 import logging
-from contextlib import contextmanager
 import os
 import re
 import uuid
-import functools
-from typing import Optional, Generator, Callable, List
+from contextlib import contextmanager
 from threading import RLock
+from typing import Callable, Generator, List, Optional
 
 import jedi
 
-from . import lsp, uris, _utils
+from . import _utils, lsp, uris
 
 log = logging.getLogger(__name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,3 +104,6 @@ addopts = "--cov-report html --cov-report term --junitxml=pytest.xml --cov pylsp
 
 [tool.coverage.run]
 concurrency = ["multiprocessing", "thread"]
+
+[tool.isort]
+profile = "black"

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,7 @@
 # Copyright 2017-2020 Palantir Technologies, Inc.
 # Copyright 2021- Python Language Server Contributors.
 
-from setuptools import setup, find_packages
-
+from setuptools import find_packages, setup
 
 if __name__ == "__main__":
     setup(

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -2,8 +2,8 @@
 # Copyright 2021- Python Language Server Contributors.
 
 import pytest
-from pylsp import IS_WIN
 
+from pylsp import IS_WIN
 
 unix_only = pytest.mark.skipif(IS_WIN, reason="Unix only")
 windows_only = pytest.mark.skipif(not IS_WIN, reason="Windows only")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,6 +3,7 @@
 
 """ py.test configuration"""
 import logging
+
 from pylsp.__main__ import LOG_FORMAT
 
 logging.basicConfig(level=logging.DEBUG, format=LOG_FORMAT)

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -3,12 +3,10 @@
 
 import os
 from io import StringIO
+from test.test_utils import CALL_TIMEOUT_IN_SECONDS, ClientServerPair
 from unittest.mock import MagicMock
 
-from test.test_utils import ClientServerPair, CALL_TIMEOUT_IN_SECONDS
-
 import pytest
-
 from pylsp_jsonrpc.dispatchers import MethodDispatcher
 from pylsp_jsonrpc.endpoint import Endpoint
 from pylsp_jsonrpc.exceptions import JsonRpcException
@@ -16,8 +14,7 @@ from pylsp_jsonrpc.exceptions import JsonRpcException
 from pylsp import uris
 from pylsp.config.config import Config
 from pylsp.python_lsp import PythonLSPServer
-from pylsp.workspace import Workspace, Document
-
+from pylsp.workspace import Document, Workspace
 
 DOC_URI = uris.from_fs_path(__file__)
 DOC = """import sys

--- a/test/plugins/test_autoimport.py
+++ b/test/plugins/test_autoimport.py
@@ -1,10 +1,9 @@
 # Copyright 2022- Python Language Server Contributors.
 
-from typing import Any, Dict, List
-from unittest.mock import Mock, patch
-
 from test.test_notebook_document import wait_for_condition
 from test.test_utils import send_initialize_request, send_notebook_did_open
+from typing import Any, Dict, List
+from unittest.mock import Mock, patch
 
 import jedi
 import parso
@@ -23,7 +22,6 @@ from pylsp.plugins.rope_autoimport import (
     pylsp_completions as pylsp_autoimport_completions,
 )
 from pylsp.workspace import Workspace
-
 
 DOC_URI = uris.from_fs_path(__file__)
 

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -4,21 +4,19 @@
 import math
 import os
 import sys
-
 from pathlib import Path
-from typing import NamedTuple, Dict
+from typing import Dict, NamedTuple
 
 import pytest
 
-from pylsp import uris, lsp
-from pylsp.workspace import Document
-from pylsp.plugins.jedi_completion import pylsp_completions as pylsp_jedi_completions
+from pylsp import lsp, uris
+from pylsp._utils import JEDI_VERSION
 from pylsp.plugins.jedi_completion import (
     pylsp_completion_item_resolve as pylsp_jedi_completion_item_resolve,
 )
+from pylsp.plugins.jedi_completion import pylsp_completions as pylsp_jedi_completions
 from pylsp.plugins.rope_completion import pylsp_completions as pylsp_rope_completions
-from pylsp._utils import JEDI_VERSION
-
+from pylsp.workspace import Document
 
 PY2 = sys.version[0] == "2"
 LINUX = sys.platform.startswith("linux")

--- a/test/plugins/test_definitions.py
+++ b/test/plugins/test_definitions.py
@@ -7,7 +7,6 @@ from pylsp import uris
 from pylsp.plugins.definition import pylsp_definitions
 from pylsp.workspace import Document
 
-
 DOC_URI = uris.from_fs_path(__file__)
 DOC = """def a():
     pass

--- a/test/plugins/test_flake8_lint.py
+++ b/test/plugins/test_flake8_lint.py
@@ -1,14 +1,14 @@
 # Copyright 2017-2020 Palantir Technologies, Inc.
 # Copyright 2021- Python Language Server Contributors.
 
-import tempfile
 import os
+import tempfile
 from textwrap import dedent
 from unittest.mock import patch
+
 from pylsp import lsp, uris
 from pylsp.plugins import flake8_lint
 from pylsp.workspace import Document
-
 
 DOC_URI = uris.from_fs_path(__file__)
 DOC = """import pylsp

--- a/test/plugins/test_highlight.py
+++ b/test/plugins/test_highlight.py
@@ -2,9 +2,8 @@
 # Copyright 2021- Python Language Server Contributors.
 
 from pylsp import lsp, uris
-from pylsp.workspace import Document
 from pylsp.plugins.highlight import pylsp_document_highlight
-
+from pylsp.workspace import Document
 
 DOC_URI = uris.from_fs_path(__file__)
 DOC = """a = "hello"

--- a/test/plugins/test_jedi_rename.py
+++ b/test/plugins/test_jedi_rename.py
@@ -4,10 +4,10 @@
 import os
 
 import pytest
+
 from pylsp import uris
 from pylsp.plugins.jedi_rename import pylsp_rename
 from pylsp.workspace import Document
-
 
 DOC_NAME = "test1.py"
 DOC = """class Test1():

--- a/test/plugins/test_mccabe_lint.py
+++ b/test/plugins/test_mccabe_lint.py
@@ -2,8 +2,8 @@
 # Copyright 2021- Python Language Server Contributors.
 
 from pylsp import lsp, uris
-from pylsp.workspace import Document
 from pylsp.plugins import mccabe_lint
+from pylsp.workspace import Document
 
 DOC_URI = uris.from_fs_path(__file__)
 DOC = """def hello():

--- a/test/plugins/test_pycodestyle_lint.py
+++ b/test/plugins/test_pycodestyle_lint.py
@@ -6,8 +6,8 @@ import os
 import pytest
 
 from pylsp import lsp, uris
-from pylsp.workspace import Document
 from pylsp.plugins import pycodestyle_lint
+from pylsp.workspace import Document
 
 DOC_URI = uris.from_fs_path(__file__)
 DOC = """import sys

--- a/test/plugins/test_pydocstyle_lint.py
+++ b/test/plugins/test_pydocstyle_lint.py
@@ -2,9 +2,10 @@
 # Copyright 2021- Python Language Server Contributors.
 
 import os
+
 from pylsp import lsp, uris
-from pylsp.workspace import Document
 from pylsp.plugins import pydocstyle_lint
+from pylsp.workspace import Document
 
 DOC_URI = uris.from_fs_path(os.path.join(os.path.dirname(__file__), "pydocstyle.py"))
 TEST_DOC_URI = uris.from_fs_path(__file__)

--- a/test/plugins/test_pyflakes_lint.py
+++ b/test/plugins/test_pyflakes_lint.py
@@ -4,8 +4,8 @@
 import sys
 
 from pylsp import lsp, uris
-from pylsp.workspace import Document
 from pylsp.plugins import pyflakes_lint
+from pylsp.workspace import Document
 
 DOC_URI = uris.from_fs_path(__file__)
 DOC = """import sys

--- a/test/plugins/test_pylint_lint.py
+++ b/test/plugins/test_pylint_lint.py
@@ -3,13 +3,13 @@
 # Copyright 2021- Python Language Server Contributors.
 
 import contextlib
-from pathlib import Path
 import os
 import tempfile
+from pathlib import Path
 
 from pylsp import lsp, uris
-from pylsp.workspace import Document, Workspace
 from pylsp.plugins import pylint_lint
+from pylsp.workspace import Document, Workspace
 
 DOC_URI = uris.from_fs_path(__file__)
 DOC = """import sys

--- a/test/plugins/test_references.py
+++ b/test/plugins/test_references.py
@@ -6,9 +6,8 @@ import os
 import pytest
 
 from pylsp import uris
-from pylsp.workspace import Document
 from pylsp.plugins.references import pylsp_references
-
+from pylsp.workspace import Document
 
 DOC1_NAME = "test1.py"
 DOC2_NAME = "test2.py"

--- a/test/plugins/test_rope_rename.py
+++ b/test/plugins/test_rope_rename.py
@@ -4,10 +4,10 @@
 import os
 
 import pytest
+
 from pylsp import uris
 from pylsp.plugins.rope_rename import pylsp_rename
 from pylsp.workspace import Document
-
 
 DOC_NAME = "test1.py"
 DOC = """class Test1():

--- a/test/plugins/test_signature.py
+++ b/test/plugins/test_signature.py
@@ -2,6 +2,7 @@
 # Copyright 2021- Python Language Server Contributors.
 
 import pytest
+
 from pylsp import uris
 from pylsp.plugins import signature
 from pylsp.workspace import Document

--- a/test/plugins/test_symbols.py
+++ b/test/plugins/test_symbols.py
@@ -7,10 +7,9 @@ import sys
 import pytest
 
 from pylsp import uris
-from pylsp.plugins.symbols import pylsp_document_symbols
 from pylsp.lsp import SymbolKind
+from pylsp.plugins.symbols import pylsp_document_symbols
 from pylsp.workspace import Document
-
 
 PY2 = sys.version[0] == "2"
 LINUX = sys.platform.startswith("linux")

--- a/test/plugins/test_yapf_format.py
+++ b/test/plugins/test_yapf_format.py
@@ -5,8 +5,8 @@ import pytest
 
 from pylsp import uris
 from pylsp.plugins.yapf_format import pylsp_format_document, pylsp_format_range
-from pylsp.workspace import Document
 from pylsp.text_edit import apply_text_edits
+from pylsp.workspace import Document
 
 DOC_URI = uris.from_fs_path(__file__)
 DOC = """A = [

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -1,14 +1,12 @@
 # Copyright 2021- Python Language Server Contributors.
 
-from unittest.mock import patch
-
-from test.test_utils import send_initialize_request
 from test.test_notebook_document import wait_for_condition
+from test.test_utils import send_initialize_request
+from unittest.mock import patch
 
 import pytest
 
 from pylsp import IS_WIN
-
 
 INITIALIZATION_OPTIONS = {
     "pylsp": {

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -1,7 +1,8 @@
 # Copyright 2017-2020 Palantir Technologies, Inc.
 # Copyright 2021- Python Language Server Contributors.
 
-from test.fixtures import DOC_URI, DOC
+from test.fixtures import DOC, DOC_URI
+
 from pylsp.workspace import Document
 
 

--- a/test/test_language_server.py
+++ b/test/test_language_server.py
@@ -2,15 +2,13 @@
 # Copyright 2021- Python Language Server Contributors.
 
 import os
-import time
 import sys
-
+import time
 from test.test_utils import ClientServerPair, send_initialize_request
 
+import pytest
 from flaky import flaky
 from pylsp_jsonrpc.exceptions import JsonRpcMethodNotFound
-import pytest
-
 
 RUNNING_IN_CI = bool(os.environ.get("CI"))
 

--- a/test/test_notebook_document.py
+++ b/test/test_notebook_document.py
@@ -1,19 +1,18 @@
 # Copyright 2021- Python Language Server Contributors.
 
 import time
-from unittest.mock import patch, call
-
 from test.test_utils import (
     CALL_TIMEOUT_IN_SECONDS,
     send_initialize_request,
     send_notebook_did_open,
 )
+from unittest.mock import call, patch
 
 import pytest
-from pylsp.workspace import Notebook
 
 from pylsp import IS_WIN
 from pylsp.lsp import NotebookCellKind
+from pylsp.workspace import Notebook
 
 
 def wait_for_condition(condition, timeout=CALL_TIMEOUT_IN_SECONDS):

--- a/test/test_text_edit.py
+++ b/test/test_text_edit.py
@@ -1,8 +1,8 @@
 # Copyright 2017-2020 Palantir Technologies, Inc.
 # Copyright 2021- Python Language Server Contributors.
 
-from pylsp.text_edit import OverLappingTextEditException, apply_text_edits
 from pylsp import uris
+from pylsp.text_edit import OverLappingTextEditException, apply_text_edits
 
 DOC_URI = uris.from_fs_path(__file__)
 

--- a/test/test_uris.py
+++ b/test/test_uris.py
@@ -2,7 +2,9 @@
 # Copyright 2021- Python Language Server Contributors.
 
 from test import unix_only, windows_only
+
 import pytest
+
 from pylsp import uris
 
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -4,18 +4,17 @@
 import multiprocessing
 import os
 import sys
-from threading import Thread
 import time
+from threading import Thread
 from typing import Any, Dict, List
 from unittest import mock
 
-from flaky import flaky
 from docstring_to_markdown import UnknownFormatError
+from flaky import flaky
 
 from pylsp import _utils
 from pylsp.lsp import NotebookCellKind
 from pylsp.python_lsp import PythonLSPServer, start_io_lang_server
-
 
 CALL_TIMEOUT_IN_SECONDS = 30
 

--- a/test/test_workspace.py
+++ b/test/test_workspace.py
@@ -3,8 +3,8 @@ import os
 import pathlib
 
 import pytest
-from pylsp import uris
 
+from pylsp import uris
 
 DOC_URI = uris.from_fs_path(__file__)
 NOTEBOOK_URI = uris.from_fs_path("notebook_uri")


### PR DESCRIPTION
This is just me getting as many file changes into this project as possible for fame and glory 🎉 

Fun aside, a couple of times already I had to address some import order things, and TBH, I am just not good at spotting that. That's why I think it's helpful using `isort`. Since we're using `black` as well, it's [recommended to use the black profile for isort](https://pycqa.github.io/isort/docs/configuration/black_compatibility.html).

This PR adds isort checks to the static code analysis pipeline and runs `isort --profile black` on the repo once.