### PR TITLE
Fix extra end line increment in autopep8 plugin

### DIFF
--- a/pylsp/plugins/autopep8_format.py
+++ b/pylsp/plugins/autopep8_format.py
@@ -33,7 +33,7 @@ def pylsp_format_range(
     range["end"]["character"] = 0
 
     # Add 1 for 1-indexing vs LSP's 0-indexing
-    line_range = (range["start"]["line"] + 1, range["end"]["line"] + 1)
+    line_range = (range["start"]["line"] + 1, range["end"]["line"])
     return _format(config, document, line_range=line_range)
 
 


### PR DESCRIPTION
This is fixing a bug where the line range end (inclusive) is incremented twice, first line 32 just above resulting in formatting an extra line of text.

Tested with Spyder, before:

https://github.com/python-lsp/python-lsp-server/assets/26257211/9db88c47-d251-42f1-83f1-14f897230665

After:

https://github.com/python-lsp/python-lsp-server/assets/26257211/81e79f6c-ae9d-4440-bae2-ec8fe7650a76

Same logic in the black plugin:
- https://github.com/python-lsp/python-lsp-black/blob/307e87dbf74ff0227991d88cbc734113ce3fff68/pylsp_black/plugin.py#L44
- https://github.com/python-lsp/python-lsp-black/blob/307e87dbf74ff0227991d88cbc734113ce3fff68/pylsp_black/plugin.py#L70