### PR TITLE
Remove ujson dependency and use python's json module

### DIFF
--- a/pylsp/__main__.py
+++ b/pylsp/__main__.py
@@ -2,15 +2,11 @@
 # Copyright 2021- Python Language Server Contributors.
 
 import argparse
+import json
 import logging
 import logging.config
 import sys
 import time
-
-try:
-    import ujson as json
-except Exception:  # pylint: disable=broad-except
-    import json
 
 from .python_lsp import (
     PythonLSPServer,

--- a/pylsp/plugins/pylint_lint.py
+++ b/pylsp/plugins/pylint_lint.py
@@ -4,6 +4,7 @@
 
 """Linter plugin for pylint."""
 import collections
+import json
 import logging
 import sys
 import re
@@ -13,10 +14,6 @@ import shlex
 
 from pylsp import hookimpl, lsp
 
-try:
-    import ujson as json
-except Exception:  # pylint: disable=broad-except
-    import json
 
 log = logging.getLogger(__name__)
 

--- a/pylsp/python_lsp.py
+++ b/pylsp/python_lsp.py
@@ -2,13 +2,13 @@
 # Copyright 2021- Python Language Server Contributors.
 
 from functools import partial
+import json
 import logging
 import os
 import socketserver
 import threading
 import uuid
 from typing import List, Dict, Any
-import ujson as json
 
 from pylsp_jsonrpc.dispatchers import MethodDispatcher
 from pylsp_jsonrpc.endpoint import Endpoint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
     "jedi>=0.17.2,<0.20.0",
     "pluggy>=1.0.0",
     "python-lsp-jsonrpc>=1.1.0,<2.0.0",
-    "ujson>=3.0.0",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
The ujson dependency ships a C-extension via a wheel which could cause unnecessary problems due to different versions of glibc in different environments, especially on NixOS:

```
import ujson as json
ImportError: /nix/store/9v5d40jyvmwgnq1nj8f19ji2rcc5dksd-glibc-2.37-45/lib/libc.so.6: version `GLIBC_2.38' not found (required by /nix/store/myw67gkgayf3s2mniij7zwd79lxy8v0k-gcc-12.3.0-lib/lib/libstdc++.so.6)
```

I propose removing this dependency, since I claim that the performance gain it did more than four years ago (added in 1c0c54079b093728ca6d3acb99d1c230708619e6) is not that much relevant any more. Here is a benchmark of several json implementations: https://github.com/TkTech/json_benchmark. The builtin `json` module is even faster than `ujson` in 50% of their benchmarks.

I claim, replacing `ujson` with the standard `json` module does not make any difference in practice; but it avoids compatability issues.