### PR TITLE
Fix optional dependency version for autopep8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ all = [
     "yapf>=0.33.0",
     "whatthepatch>=1.0.2,<2.0.0"
 ]
-autopep8 = ["autopep8>=1.6.0,<2.1.0"]
+autopep8 = ["autopep8>=2.0.4,<2.1.0"]
 flake8 = ["flake8>=6.1.0,<7"]
 mccabe = ["mccabe>=0.7.0,<0.8.0"]
 pycodestyle = ["pycodestyle>=2.11.0,<2.12.0"]


### PR DESCRIPTION
This ensures the same version of autopep8 is installed whether the user passes "python-lsp-server[all]" or "python-lsp-server[autopep8]" to pip.

Fixes #513