### PR TITLE
Allow `extra_paths` to be placed in front of `sys.path`

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -21,6 +21,7 @@ This server can be configured using the `workspace/didChangeConfiguration` metho
 | `pylsp.plugins.flake8.select` | `array` of unique `string` items | List of errors and warnings to enable. | `null` |
 | `pylsp.plugins.jedi.auto_import_modules` | `array` of `string` items | List of module names for jedi.settings.auto_import_modules. | `["numpy"]` |
 | `pylsp.plugins.jedi.extra_paths` | `array` of `string` items | Define extra paths for jedi.Script. | `[]` |
+| `pylsp.plugins.jedi.prioritize` | `boolean` | Whether to place extra_paths at the beginning (true) or end (false) of `sys.path` | `false` |
 | `pylsp.plugins.jedi.env_vars` | `object` | Define environment variables for jedi.Script and Jedi.names. | `null` |
 | `pylsp.plugins.jedi.environment` | `string` | Define environment for jedi.Script and Jedi.names. | `null` |
 | `pylsp.plugins.jedi_completion.enabled` | `boolean` | Enable or disable the plugin. | `true` |

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -21,7 +21,7 @@ This server can be configured using the `workspace/didChangeConfiguration` metho
 | `pylsp.plugins.flake8.select` | `array` of unique `string` items | List of errors and warnings to enable. | `null` |
 | `pylsp.plugins.jedi.auto_import_modules` | `array` of `string` items | List of module names for jedi.settings.auto_import_modules. | `["numpy"]` |
 | `pylsp.plugins.jedi.extra_paths` | `array` of `string` items | Define extra paths for jedi.Script. | `[]` |
-| `pylsp.plugins.jedi.prioritize` | `boolean` | Whether to place extra_paths at the beginning (true) or end (false) of `sys.path` | `false` |
+| `pylsp.plugins.jedi.prioritize_extra_paths` | `boolean` | Whether to place extra_paths at the beginning (true) or end (false) of `sys.path` | `false` |
 | `pylsp.plugins.jedi.env_vars` | `object` | Define environment variables for jedi.Script and Jedi.names. | `null` |
 | `pylsp.plugins.jedi.environment` | `string` | Define environment for jedi.Script and Jedi.names. | `null` |
 | `pylsp.plugins.jedi_completion.enabled` | `boolean` | Enable or disable the plugin. | `true` |

--- a/pylsp/config/schema.json
+++ b/pylsp/config/schema.json
@@ -151,6 +151,11 @@
       },
       "description": "Define extra paths for jedi.Script."
     },
+    "pylsp.plugins.jedi.prioritize": {
+      "type": "boolean",
+      "default": false,
+      "description": "Whether to place extra_paths at the beginning (true) or end (false) of `sys.path`"
+    },
     "pylsp.plugins.jedi.env_vars": {
       "type": [
         "object",

--- a/pylsp/config/schema.json
+++ b/pylsp/config/schema.json
@@ -151,7 +151,7 @@
       },
       "description": "Define extra paths for jedi.Script."
     },
-    "pylsp.plugins.jedi.prioritize": {
+    "pylsp.plugins.jedi.prioritize_extra_paths": {
       "type": "boolean",
       "default": false,
       "description": "Whether to place extra_paths at the beginning (true) or end (false) of `sys.path`"

--- a/pylsp/workspace.py
+++ b/pylsp/workspace.py
@@ -548,11 +548,8 @@ class Document:
 
         environment = self.get_enviroment(environment_path, env_vars=env_vars)
 
-        sys_path = list(self._extra_sys_path) + environment.get_sys_path()
-        if prioritize:
-            sys_path += extra_paths + sys_path
-        else:
-            sys_path += sys_path + extra_paths
+        sys_path = self.sys_path(environment_path, env_vars, prioritize, extra_paths)
+
         project_path = self._workspace.root_path
 
         # Extend sys_path with document's path if requested
@@ -587,14 +584,18 @@ class Document:
 
         return environment
 
-    def sys_path(self, environment_path=None, env_vars=None):
-        # TODO: when safe to break API, remove this method.
+    def sys_path(self, environment_path=None, env_vars=None, prioritize=False, extra_paths=[]):
         # Copy our extra sys path
         path = list(self._extra_sys_path)
         environment = self.get_enviroment(
             environment_path=environment_path, env_vars=env_vars
         )
         path.extend(environment.get_sys_path())
+        if prioritize:
+            path += extra_paths + path
+        else:
+            path += path + extra_paths
+
         return path
 
 

--- a/pylsp/workspace.py
+++ b/pylsp/workspace.py
@@ -584,7 +584,9 @@ class Document:
 
         return environment
 
-    def sys_path(self, environment_path=None, env_vars=None, prioritize=False, extra_paths=[]):
+    def sys_path(
+        self, environment_path=None, env_vars=None, prioritize=False, extra_paths=[]
+    ):
         # Copy our extra sys path
         path = list(self._extra_sys_path)
         environment = self.get_enviroment(

--- a/pylsp/workspace.py
+++ b/pylsp/workspace.py
@@ -521,7 +521,7 @@ class Document:
         extra_paths = []
         environment_path = None
         env_vars = None
-        prioritize = False
+        prioritize_extra_paths = False
 
         if self._config:
             jedi_settings = self._config.plugin_settings(
@@ -538,7 +538,7 @@ class Document:
 
             extra_paths = jedi_settings.get("extra_paths") or []
             env_vars = jedi_settings.get("env_vars")
-            prioritize = jedi_settings.get("prioritize")
+            prioritize_extra_paths = jedi_settings.get("prioritize_extra_paths")
 
         # Drop PYTHONPATH from env_vars before creating the environment to
         # ensure that Jedi can startup properly without module name collision.
@@ -547,8 +547,7 @@ class Document:
         env_vars.pop("PYTHONPATH", None)
 
         environment = self.get_enviroment(environment_path, env_vars=env_vars)
-
-        sys_path = self.sys_path(environment_path, env_vars, prioritize, extra_paths)
+        sys_path = self.sys_path(environment_path, env_vars, prioritize_extra_paths, extra_paths)
 
         project_path = self._workspace.root_path
 
@@ -585,7 +584,7 @@ class Document:
         return environment
 
     def sys_path(
-        self, environment_path=None, env_vars=None, prioritize=False, extra_paths=[]
+        self, environment_path=None, env_vars=None, prioritize_extra_paths=False, extra_paths=[]
     ):
         # Copy our extra sys path
         path = list(self._extra_sys_path)
@@ -593,7 +592,7 @@ class Document:
             environment_path=environment_path, env_vars=env_vars
         )
         path.extend(environment.get_sys_path())
-        if prioritize:
+        if prioritize_extra_paths:
             path += extra_paths + path
         else:
             path += path + extra_paths

--- a/pylsp/workspace.py
+++ b/pylsp/workspace.py
@@ -547,7 +547,9 @@ class Document:
         env_vars.pop("PYTHONPATH", None)
 
         environment = self.get_enviroment(environment_path, env_vars=env_vars)
-        sys_path = self.sys_path(environment_path, env_vars, prioritize_extra_paths, extra_paths)
+        sys_path = self.sys_path(
+            environment_path, env_vars, prioritize_extra_paths, extra_paths
+        )
 
         project_path = self._workspace.root_path
 
@@ -584,7 +586,11 @@ class Document:
         return environment
 
     def sys_path(
-        self, environment_path=None, env_vars=None, prioritize_extra_paths=False, extra_paths=[]
+        self,
+        environment_path=None,
+        env_vars=None,
+        prioritize_extra_paths=False,
+        extra_paths=[],
     ):
         # Copy our extra sys path
         path = list(self._extra_sys_path)

--- a/pylsp/workspace.py
+++ b/pylsp/workspace.py
@@ -521,6 +521,7 @@ class Document:
         extra_paths = []
         environment_path = None
         env_vars = None
+        prioritize = False
 
         if self._config:
             jedi_settings = self._config.plugin_settings(
@@ -537,19 +538,21 @@ class Document:
 
             extra_paths = jedi_settings.get("extra_paths") or []
             env_vars = jedi_settings.get("env_vars")
+            prioritize = jedi_settings.get("prioritize")
 
-        # Drop PYTHONPATH from env_vars before creating the environment because that makes
-        # Jedi throw an error.
+        # Drop PYTHONPATH from env_vars before creating the environment to
+        # ensure that Jedi can startup properly without module name collision.
         if env_vars is None:
             env_vars = os.environ.copy()
         env_vars.pop("PYTHONPATH", None)
 
-        environment = (
-            self.get_enviroment(environment_path, env_vars=env_vars)
-            if environment_path
-            else None
-        )
-        sys_path = self.sys_path(environment_path, env_vars=env_vars) + extra_paths
+        environment = self.get_enviroment(environment_path, env_vars=env_vars)
+
+        sys_path = list(self._extra_sys_path) + environment.get_sys_path()
+        if prioritize:
+            sys_path += extra_paths + sys_path
+        else:
+            sys_path += sys_path + extra_paths
         project_path = self._workspace.root_path
 
         # Extend sys_path with document's path if requested
@@ -559,7 +562,7 @@ class Document:
         kwargs = {
             "code": self.source,
             "path": self.path,
-            "environment": environment,
+            "environment": environment if environment_path else None,
             "project": jedi.Project(path=project_path, sys_path=sys_path),
         }
 
@@ -585,8 +588,8 @@ class Document:
         return environment
 
     def sys_path(self, environment_path=None, env_vars=None):
+        # TODO: when safe to break API, remove this method.
         # Copy our extra sys path
-        # TODO: when safe to break API, use env_vars explicitly to pass to create_environment
         path = list(self._extra_sys_path)
         environment = self.get_enviroment(
             environment_path=environment_path, env_vars=env_vars

--- a/test/test_workspace.py
+++ b/test/test_workspace.py
@@ -70,7 +70,7 @@ def test_non_root_project(pylsp, metafiles) -> None:
     test_uri = uris.from_fs_path(os.path.join(project_root, "hello/test.py"))
     pylsp.workspace.put_document(test_uri, "assert True")
     test_doc = pylsp.workspace.get_document(test_uri)
-    assert project_root in test_doc.sys_path()
+    assert project_root in test_doc.get_enviroment().get_sys_path()
 
 
 def test_root_project_with_no_setup_py(pylsp) -> None:
@@ -79,7 +79,7 @@ def test_root_project_with_no_setup_py(pylsp) -> None:
     test_uri = uris.from_fs_path(os.path.join(workspace_root, "hello/test.py"))
     pylsp.workspace.put_document(test_uri, "assert True")
     test_doc = pylsp.workspace.get_document(test_uri)
-    assert workspace_root in test_doc.sys_path()
+    assert workspace_root in test_doc.get_enviroment().get_sys_path()
 
 
 def test_multiple_workspaces_from_initialize(pylsp_w_workspace_folders) -> None:

--- a/test/test_workspace.py
+++ b/test/test_workspace.py
@@ -70,7 +70,7 @@ def test_non_root_project(pylsp, metafiles) -> None:
     test_uri = uris.from_fs_path(os.path.join(project_root, "hello/test.py"))
     pylsp.workspace.put_document(test_uri, "assert True")
     test_doc = pylsp.workspace.get_document(test_uri)
-    assert project_root in test_doc.get_enviroment().get_sys_path()
+    assert project_root in test_doc.sys_path()
 
 
 def test_root_project_with_no_setup_py(pylsp) -> None:
@@ -79,7 +79,7 @@ def test_root_project_with_no_setup_py(pylsp) -> None:
     test_uri = uris.from_fs_path(os.path.join(workspace_root, "hello/test.py"))
     pylsp.workspace.put_document(test_uri, "assert True")
     test_doc = pylsp.workspace.get_document(test_uri)
-    assert workspace_root in test_doc.get_enviroment().get_sys_path()
+    assert workspace_root in test_doc.sys_path()
 
 
 def test_multiple_workspaces_from_initialize(pylsp_w_workspace_folders) -> None:


### PR DESCRIPTION
Add `pylsp.plugins.jedi.prioritize` configuration key and prepend/append `extra_paths` to the environment `sys.path` accordingly.

This modifies the call signature of `Document.sys_path`. Will this require a minor release bump?