### PR TITLE
Fix progress reporting with autoimport plugin

### DIFF
--- a/pylsp/plugins/rope_autoimport.py
+++ b/pylsp/plugins/rope_autoimport.py
@@ -37,7 +37,7 @@ class AutoimportCache:
         config: Config,
         workspace: Workspace,
         files: Optional[List[Document]] = None,
-        single_thread: Optional[bool] = False,
+        single_thread: Optional[bool] = True,
     ):
         if self.is_blocked():
             return

--- a/test/plugins/test_autoimport.py
+++ b/test/plugins/test_autoimport.py
@@ -313,7 +313,7 @@ def test_autoimport_code_actions_and_completions_for_notebook_document(
     )
     assert rope_autoimport_settings.get("completions", {}).get("enabled", False) is True
     assert rope_autoimport_settings.get("memory", False) is True
-    wait_for_condition(lambda: not cache.thread.is_alive())
+    wait_for_condition(lambda: not cache.is_blocked())
 
     # 1.
     quick_fixes = server.code_actions("cell_1_uri", {}, make_context("os", 0, 0, 2))


### PR DESCRIPTION
This is temporary fix, until someone can make proper fix by resolving issue with thread, seems like it just hungs indefinitely instead of reporting progress.

Also, this thread does not exit properly, and pylsp does not exit after editor is closed.

Fixes #529.
Refs #374