### PR TITLE
Remove `.config/flake8` reference in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Like all language servers, configuration can be passed from the client that talk
 `python-lsp-server` depends on other tools, like flake8 and pycodestyle. These tools can be configured via settings passed from the client (as above), or alternatively from other configuration sources. The following sources are available:
 
 - `pycodestyle`: discovered in `~/.config/pycodestyle`, `setup.cfg`, `tox.ini` and `pycodestyle.cfg`.
-- `flake8`: discovered in `~/.config/flake8`, `.flake8`, `setup.cfg` and `tox.ini`
+- `flake8`: discovered in `.flake8`, `setup.cfg` and `tox.ini`
 
 The default configuration sources are `pycodestyle` and `pyflakes`. If you would like to use `flake8`, you will need to:
 


### PR DESCRIPTION
Flake8 no longer supports `~/.config/flake8` as of version 4.0



> Due to constant confusion by users, user-level Flake8 configuration files are no longer supported. Files will not be searched for in the user’s home directory (e.g., ~/.flake8) nor in the XDG config directory (e.g., ~/.config/flake8). (See also [#1404](https://github.com/pycqa/flake8/pull/1404)).

[4.0.0 Release Notes](https://flake8.pycqa.org/en/latest/release-notes/4.0.0.html#backwards-incompatible-changes)