### PR TITLE
Add fallback for `ujson` import

### DIFF
--- a/pylsp/python_lsp.py
+++ b/pylsp/python_lsp.py
@@ -9,7 +9,11 @@ import uuid
 from functools import partial
 from typing import Any, Dict, List
 
-import ujson as json
+try:
+    import ujson as json
+except Exception:
+    import json
+
 from pylsp_jsonrpc.dispatchers import MethodDispatcher
 from pylsp_jsonrpc.endpoint import Endpoint
 from pylsp_jsonrpc.streams import JsonRpcStreamReader, JsonRpcStreamWriter


### PR DESCRIPTION
Add fallback for ujson library import
The same logic in [pylsp/__main__.py](https://github.com/python-lsp/python-lsp-server/blob/433c6a66b110a7e3346f869d0f563b602c994322/pylsp/__main__.py#L10-L13) and in [pylsp/plugins/pylint_lint.py](https://github.com/python-lsp/python-lsp-server/blob/433c6a66b110a7e3346f869d0f563b602c994322/pylsp/plugins/pylint_lint.py#L17-L20)