### PR TITLE
Add `extendSelect` option to flake8 plugin

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -9,6 +9,7 @@ This server can be configured using the `workspace/didChangeConfiguration` metho
 | `pylsp.plugins.flake8.enabled` | `boolean` | Enable or disable the plugin. | `false` |
 | `pylsp.plugins.flake8.exclude` | `array` of `string` items | List of files or directories to exclude. | `[]` |
 | `pylsp.plugins.flake8.extendIgnore` | `array` of `string` items | List of errors and warnings to append to ignore list. | `[]` |
+| `pylsp.plugins.flake8.extendSelect` | `array` of `string` items | List of errors and warnings to append to select list. | `[]` |
 | `pylsp.plugins.flake8.executable` | `string` | Path to the flake8 executable. | `"flake8"` |
 | `pylsp.plugins.flake8.filename` | `string` | Only check for filenames matching the patterns in this list. | `null` |
 | `pylsp.plugins.flake8.hangClosing` | `boolean` | Hang closing bracket instead of matching indentation of opening bracket's line. | `null` |

--- a/pylsp/config/flake8_conf.py
+++ b/pylsp/config/flake8_conf.py
@@ -27,6 +27,7 @@ OPTIONS = [
     # flake8
     ("exclude", "plugins.flake8.exclude", list),
     ("extend-ignore", "plugins.flake8.extendIgnore", list),
+    ("extend-select", "plugins.flake8.extendSelect", list),
     ("filename", "plugins.flake8.filename", list),
     ("hang-closing", "plugins.flake8.hangClosing", bool),
     ("ignore", "plugins.flake8.ignore", list),

--- a/pylsp/config/schema.json
+++ b/pylsp/config/schema.json
@@ -53,6 +53,14 @@
       },
       "description": "List of errors and warnings to append to ignore list."
     },
+    "pylsp.plugins.flake8.extendSelect": {
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "string"
+      },
+      "description": "List of errors and warnings to append to select list."
+    },
     "pylsp.plugins.flake8.executable": {
       "type": "string",
       "default": "flake8",

--- a/pylsp/plugins/flake8_lint.py
+++ b/pylsp/plugins/flake8_lint.py
@@ -72,6 +72,7 @@ def pylsp_lint(workspace, document):
             "config": settings.get("config"),
             "exclude": settings.get("exclude"),
             "extend-ignore": settings.get("extendIgnore"),
+            "extend-select": settings.get("extendSelect"),
             "filename": settings.get("filename"),
             "hang-closing": settings.get("hangClosing"),
             "ignore": ignores or None,


### PR DESCRIPTION
`--extend-select` allows adding error codes without overriding the default `--select`