### PR TITLE
Use macOS 13 to run our tests on CI

### DIFF
--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   build:
     name: Mac Py${{ matrix.PYTHON_VERSION }}
-    runs-on: macos-latest
+    runs-on: macos-13
     env:
       CI: 'true'
       OS: 'macos'


### PR DESCRIPTION
This is because tests fail on macOS 14, the latest OS available on Github.