### PR TITLE
Add version support to `workspace/publishDiagnostics`

### DIFF
--- a/pylsp/python_lsp.py
+++ b/pylsp/python_lsp.py
@@ -442,7 +442,7 @@ class PythonLSPServer(MethodDispatcher):
         workspace = self._match_uri_to_workspace(doc_uri)
         document_object = workspace.documents.get(doc_uri, None)
         if isinstance(document_object, Document):
-            self._lint_text_document(doc_uri, workspace, is_saved, doc_version)
+            self._lint_text_document(doc_uri, workspace, is_saved, document_object.version)
         elif isinstance(document_object, Notebook):
             self._lint_notebook_document(document_object, workspace)
 

--- a/pylsp/python_lsp.py
+++ b/pylsp/python_lsp.py
@@ -447,8 +447,9 @@ class PythonLSPServer(MethodDispatcher):
             self._lint_notebook_document(document_object, workspace)
 
     def _lint_text_document(self, doc_uri, workspace, is_saved):
+        document_object = workspace.documents.get(doc_uri, None)
         workspace.publish_diagnostics(
-            doc_uri, flatten(self._hook("pylsp_lint", doc_uri, is_saved=is_saved))
+            doc_uri, flatten(self._hook("pylsp_lint", doc_uri, is_saved=is_saved)), document_object.version,
         )
 
     def _lint_notebook_document(self, notebook_document, workspace):

--- a/pylsp/python_lsp.py
+++ b/pylsp/python_lsp.py
@@ -442,14 +442,13 @@ class PythonLSPServer(MethodDispatcher):
         workspace = self._match_uri_to_workspace(doc_uri)
         document_object = workspace.documents.get(doc_uri, None)
         if isinstance(document_object, Document):
-            self._lint_text_document(doc_uri, workspace, is_saved=is_saved)
+            self._lint_text_document(doc_uri, workspace, is_saved, doc_version)
         elif isinstance(document_object, Notebook):
             self._lint_notebook_document(document_object, workspace)
 
-    def _lint_text_document(self, doc_uri, workspace, is_saved):
-        document_object = workspace.documents.get(doc_uri, None)
+    def _lint_text_document(self, doc_uri, workspace, is_saved, doc_version=None):
         workspace.publish_diagnostics(
-            doc_uri, flatten(self._hook("pylsp_lint", doc_uri, is_saved=is_saved)), document_object.version,
+            doc_uri, flatten(self._hook("pylsp_lint", doc_uri, is_saved=is_saved)), doc_version,
         )
 
     def _lint_notebook_document(self, notebook_document, workspace):

--- a/pylsp/workspace.py
+++ b/pylsp/workspace.py
@@ -177,9 +177,17 @@ class Workspace:
         return self._endpoint.request(self.M_APPLY_EDIT, {"edit": edit})
 
     def publish_diagnostics(self, doc_uri, diagnostics, doc_version=None):
+        params = {
+            "uri": doc_uri,
+            "diagnostics": diagnostics,
+        }
+
+        if doc_version:
+            params["version"] = doc_version
+
         self._endpoint.notify(
             self.M_PUBLISH_DIAGNOSTICS,
-            params={"uri": doc_uri, "diagnostics": diagnostics, "version": doc_version},
+            params=params,
         )
 
     @contextmanager

--- a/pylsp/workspace.py
+++ b/pylsp/workspace.py
@@ -176,10 +176,10 @@ class Workspace:
     def apply_edit(self, edit):
         return self._endpoint.request(self.M_APPLY_EDIT, {"edit": edit})
 
-    def publish_diagnostics(self, doc_uri, diagnostics):
+    def publish_diagnostics(self, doc_uri, diagnostics, doc_version):
         self._endpoint.notify(
             self.M_PUBLISH_DIAGNOSTICS,
-            params={"uri": doc_uri, "diagnostics": diagnostics},
+            params={"uri": doc_uri, "diagnostics": diagnostics, "version": doc_version},
         )
 
     @contextmanager

--- a/pylsp/workspace.py
+++ b/pylsp/workspace.py
@@ -176,7 +176,7 @@ class Workspace:
     def apply_edit(self, edit):
         return self._endpoint.request(self.M_APPLY_EDIT, {"edit": edit})
 
-    def publish_diagnostics(self, doc_uri, diagnostics, doc_version):
+    def publish_diagnostics(self, doc_uri, diagnostics, doc_version=None):
         self._endpoint.notify(
             self.M_PUBLISH_DIAGNOSTICS,
             params={"uri": doc_uri, "diagnostics": diagnostics, "version": doc_version},


### PR DESCRIPTION
Currently we do not pass version information when we are publishing diagnostics. See: [LSP protocol](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_publishDiagnostics)

Now we pass the version information so the client can create an opinion as to whether the current diagnostics are valid or not for the workspace