### PR TITLE
Fix Fedora instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ sudo apt-get install python3-pylsp
 or Fedora Linux
 
 ```
-sudo dnf install python-lsp-server
+sudo dnf install python3-lsp-server
 ```
 
 or Arch Linux


### PR DESCRIPTION
The installable package is called `python3-lsp-server`. The name
of the source (SRPM) package is called `python-lsp-server`.
The package provides `pylsp`. So `sudo dnf install pylsp` would
also work.
