### PR TITLE
Add `window/logMessage` support

### DIFF
--- a/pylsp/python_lsp.py
+++ b/pylsp/python_lsp.py
@@ -442,13 +442,17 @@ class PythonLSPServer(MethodDispatcher):
         workspace = self._match_uri_to_workspace(doc_uri)
         document_object = workspace.documents.get(doc_uri, None)
         if isinstance(document_object, Document):
-            self._lint_text_document(doc_uri, workspace, is_saved, document_object.version)
+            self._lint_text_document(
+                doc_uri, workspace, is_saved, document_object.version
+            )
         elif isinstance(document_object, Notebook):
             self._lint_notebook_document(document_object, workspace)
 
     def _lint_text_document(self, doc_uri, workspace, is_saved, doc_version=None):
         workspace.publish_diagnostics(
-            doc_uri, flatten(self._hook("pylsp_lint", doc_uri, is_saved=is_saved)), doc_version,
+            doc_uri,
+            flatten(self._hook("pylsp_lint", doc_uri, is_saved=is_saved)),
+            doc_version,
         )
 
     def _lint_notebook_document(self, notebook_document, workspace):

--- a/pylsp/workspace.py
+++ b/pylsp/workspace.py
@@ -41,6 +41,7 @@ class Workspace:
     M_INITIALIZE_PROGRESS = "window/workDoneProgress/create"
     M_APPLY_EDIT = "workspace/applyEdit"
     M_SHOW_MESSAGE = "window/showMessage"
+    M_LOG_MESSAGE = "window/logMessage"
 
     def __init__(self, root_uri, endpoint, config=None):
         self._config = config
@@ -322,6 +323,11 @@ class Workspace:
                 "token": token,
                 "value": value,
             },
+        )
+    
+    def log_message(self, message, msg_type=lsp.MessageType.Info):
+        self._endpoint.notify(
+            self.M_LOG_MESSAGE, params={"type": msg_type, "message": message}
         )
 
     def show_message(self, message, msg_type=lsp.MessageType.Info):

--- a/pylsp/workspace.py
+++ b/pylsp/workspace.py
@@ -324,7 +324,7 @@ class Workspace:
                 "value": value,
             },
         )
-    
+
     def log_message(self, message, msg_type=lsp.MessageType.Info):
         self._endpoint.notify(
             self.M_LOG_MESSAGE, params={"type": msg_type, "message": message}


### PR DESCRIPTION
This PR adds support for logging to the LSP client through the `window/logMessage` command

See: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_logMessage