### PR TITLE
Set return type to `None` for functions without returns

### DIFF
--- a/pylsp/__main__.py
+++ b/pylsp/__main__.py
@@ -25,7 +25,7 @@ LOG_FORMAT = "%(asctime)s {0} - %(levelname)s - %(name)s - %(message)s".format(
 )
 
 
-def add_arguments(parser):
+def add_arguments(parser) -> None:
     parser.description = "Python Language Server"
 
     parser.add_argument(
@@ -67,7 +67,7 @@ def add_arguments(parser):
     )
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser()
     add_arguments(parser)
     args = parser.parse_args()
@@ -94,7 +94,7 @@ def _binary_stdio():
     return stdin, stdout
 
 
-def _configure_logger(verbose=0, log_config=None, log_file=None):
+def _configure_logger(verbose=0, log_config=None, log_file=None) -> None:
     root_logger = logging.root
 
     if log_config:

--- a/pylsp/config/config.py
+++ b/pylsp/config/config.py
@@ -43,7 +43,7 @@ class PluginManager(pluggy.PluginManager):
 
 
 class Config:
-    def __init__(self, root_uri, init_opts, process_id, capabilities):
+    def __init__(self, root_uri, init_opts, process_id, capabilities) -> None:
         self._root_path = uris.to_fs_path(root_uri)
         self._root_uri = root_uri
         self._init_opts = init_opts
@@ -185,14 +185,14 @@ class Config:
             .get(plugin, {})
         )
 
-    def update(self, settings):
+    def update(self, settings) -> None:
         """Recursively merge the given settings into the current settings."""
         self.settings.cache_clear()
         self._settings = settings
         log.info("Updated settings to %s", self._settings)
         self._update_disabled_plugins()
 
-    def _update_disabled_plugins(self):
+    def _update_disabled_plugins(self) -> None:
         # All plugins default to enabled
         self._disabled_plugins = [
             plugin

--- a/pylsp/config/source.py
+++ b/pylsp/config/source.py
@@ -12,18 +12,18 @@ log = logging.getLogger(__name__)
 class ConfigSource:
     """Base class for implementing a config source."""
 
-    def __init__(self, root_path):
+    def __init__(self, root_path) -> None:
         self.root_path = root_path
         self.is_windows = sys.platform == "win32"
         self.xdg_home = os.environ.get(
             "XDG_CONFIG_HOME", os.path.expanduser("~/.config")
         )
 
-    def user_config(self):
+    def user_config(self) -> None:
         """Return user-level (i.e. home directory) configuration."""
         raise NotImplementedError()
 
-    def project_config(self, document_path):
+    def project_config(self, document_path) -> None:
         """Return project-level (i.e. workspace directory) configuration."""
         raise NotImplementedError()
 

--- a/pylsp/hookspecs.py
+++ b/pylsp/hookspecs.py
@@ -109,7 +109,9 @@ def pylsp_lint(config, workspace, document, is_saved) -> None:
 
 
 @hookspec
-def pylsp_references(config, workspace, document, position, exclude_declaration) -> None:
+def pylsp_references(
+    config, workspace, document, position, exclude_declaration
+) -> None:
     pass
 
 

--- a/pylsp/hookspecs.py
+++ b/pylsp/hookspecs.py
@@ -5,7 +5,7 @@ from pylsp import hookspec
 
 
 @hookspec
-def pylsp_code_actions(config, workspace, document, range, context) -> None:
+def pylsp_code_actions(config, workspace, document, range, context):
     pass
 
 

--- a/pylsp/hookspecs.py
+++ b/pylsp/hookspecs.py
@@ -5,17 +5,17 @@ from pylsp import hookspec
 
 
 @hookspec
-def pylsp_code_actions(config, workspace, document, range, context):
+def pylsp_code_actions(config, workspace, document, range, context) -> None:
     pass
 
 
 @hookspec
-def pylsp_code_lens(config, workspace, document):
+def pylsp_code_lens(config, workspace, document) -> None:
     pass
 
 
 @hookspec
-def pylsp_commands(config, workspace):
+def pylsp_commands(config, workspace) -> None:
     """The list of command strings supported by the server.
 
     Returns:
@@ -24,110 +24,110 @@ def pylsp_commands(config, workspace):
 
 
 @hookspec
-def pylsp_completions(config, workspace, document, position, ignored_names):
+def pylsp_completions(config, workspace, document, position, ignored_names) -> None:
     pass
 
 
 @hookspec(firstresult=True)
-def pylsp_completion_item_resolve(config, workspace, document, completion_item):
+def pylsp_completion_item_resolve(config, workspace, document, completion_item) -> None:
     pass
 
 
 @hookspec
-def pylsp_definitions(config, workspace, document, position):
+def pylsp_definitions(config, workspace, document, position) -> None:
     pass
 
 
 @hookspec
-def pylsp_dispatchers(config, workspace):
+def pylsp_dispatchers(config, workspace) -> None:
     pass
 
 
 @hookspec
-def pylsp_document_did_open(config, workspace, document):
+def pylsp_document_did_open(config, workspace, document) -> None:
     pass
 
 
 @hookspec
-def pylsp_document_did_save(config, workspace, document):
+def pylsp_document_did_save(config, workspace, document) -> None:
     pass
 
 
 @hookspec
-def pylsp_document_highlight(config, workspace, document, position):
+def pylsp_document_highlight(config, workspace, document, position) -> None:
     pass
 
 
 @hookspec
-def pylsp_document_symbols(config, workspace, document):
+def pylsp_document_symbols(config, workspace, document) -> None:
     pass
 
 
 @hookspec(firstresult=True)
-def pylsp_execute_command(config, workspace, command, arguments):
+def pylsp_execute_command(config, workspace, command, arguments) -> None:
     pass
 
 
 @hookspec
-def pylsp_experimental_capabilities(config, workspace):
+def pylsp_experimental_capabilities(config, workspace) -> None:
     pass
 
 
 @hookspec
-def pylsp_folding_range(config, workspace, document):
+def pylsp_folding_range(config, workspace, document) -> None:
     pass
 
 
 @hookspec(firstresult=True)
-def pylsp_format_document(config, workspace, document, options):
+def pylsp_format_document(config, workspace, document, options) -> None:
     pass
 
 
 @hookspec(firstresult=True)
-def pylsp_format_range(config, workspace, document, range, options):
+def pylsp_format_range(config, workspace, document, range, options) -> None:
     pass
 
 
 @hookspec(firstresult=True)
-def pylsp_hover(config, workspace, document, position):
+def pylsp_hover(config, workspace, document, position) -> None:
     pass
 
 
 @hookspec
-def pylsp_initialize(config, workspace):
+def pylsp_initialize(config, workspace) -> None:
     pass
 
 
 @hookspec
-def pylsp_initialized():
+def pylsp_initialized() -> None:
     pass
 
 
 @hookspec
-def pylsp_lint(config, workspace, document, is_saved):
+def pylsp_lint(config, workspace, document, is_saved) -> None:
     pass
 
 
 @hookspec
-def pylsp_references(config, workspace, document, position, exclude_declaration):
+def pylsp_references(config, workspace, document, position, exclude_declaration) -> None:
     pass
 
 
 @hookspec(firstresult=True)
-def pylsp_rename(config, workspace, document, position, new_name):
+def pylsp_rename(config, workspace, document, position, new_name) -> None:
     pass
 
 
 @hookspec
-def pylsp_settings(config):
+def pylsp_settings(config) -> None:
     pass
 
 
 @hookspec(firstresult=True)
-def pylsp_signature_help(config, workspace, document, position):
+def pylsp_signature_help(config, workspace, document, position) -> None:
     pass
 
 
 @hookspec
-def pylsp_workspace_configuration_changed(config, workspace):
+def pylsp_workspace_configuration_changed(config, workspace) -> None:
     pass

--- a/pylsp/plugins/_resolvers.py
+++ b/pylsp/plugins/_resolvers.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 # ---- Base class
 # -----------------------------------------------------------------------------
 class Resolver:
-    def __init__(self, callback, resolve_on_error, time_to_live=60 * 30):
+    def __init__(self, callback, resolve_on_error, time_to_live=60 * 30) -> None:
         self.callback = callback
         self.resolve_on_error = resolve_on_error
         self._cache = {}
@@ -33,7 +33,7 @@ class Resolver:
     def cached_modules(self, new_value):
         self._cached_modules = set(new_value)
 
-    def clear_outdated(self):
+    def clear_outdated(self) -> None:
         now = self.time_key()
         to_clear = [timestamp for timestamp in self._cache_ttl if timestamp < now]
         for time_key in to_clear:

--- a/pylsp/plugins/_rope_task_handle.py
+++ b/pylsp/plugins/_rope_task_handle.py
@@ -19,7 +19,7 @@ class PylspJobSet(BaseJobSet):
     _report_iter: ContextManager
     job_name: str = ""
 
-    def __init__(self, count: Optional[int], report_iter: ContextManager):
+    def __init__(self, count: Optional[int], report_iter: ContextManager) -> None:
         if count is not None:
             self.count = count
         self._reporter = report_iter.__enter__()
@@ -57,7 +57,7 @@ class PylspJobSet(BaseJobSet):
         self._report()
 
     @throttle(0.5)
-    def _report(self):
+    def _report(self) -> None:
         percent = int(self.get_percent_done())
         message = f"{self.job_name} {self.done}/{self.count}"
         log.debug(f"Reporting {message} {percent}%")
@@ -72,7 +72,7 @@ class PylspTaskHandle(BaseTaskHandle):
     workspace: Workspace
     _report: Callable[[str, str], None]
 
-    def __init__(self, workspace: Workspace):
+    def __init__(self, workspace: Workspace) -> None:
         self.workspace = workspace
         self.job_sets = []
         self.observers = []

--- a/pylsp/plugins/preload_imports.py
+++ b/pylsp/plugins/preload_imports.py
@@ -67,7 +67,7 @@ def pylsp_settings():
 
 
 @hookimpl
-def pylsp_initialize(config):
+def pylsp_initialize(config) -> None:
     for mod_name in config.plugin_settings("preload").get("modules", []):
         try:
             __import__(mod_name)

--- a/pylsp/plugins/pycodestyle_lint.py
+++ b/pylsp/plugins/pycodestyle_lint.py
@@ -65,7 +65,7 @@ def pylsp_lint(workspace, document):
 
 
 class PyCodeStyleDiagnosticReport(pycodestyle.BaseReport):
-    def __init__(self, options):
+    def __init__(self, options) -> None:
         self.diagnostics = []
         super().__init__(options=options)
 

--- a/pylsp/plugins/pydocstyle_lint.py
+++ b/pylsp/plugins/pydocstyle_lint.py
@@ -115,7 +115,7 @@ def _parse_diagnostic(document, error):
 
 
 @contextlib.contextmanager
-def _patch_sys_argv(arguments):
+def _patch_sys_argv(arguments) -> None:
     old_args = sys.argv
 
     # Preserve argv[0] since it's the executable

--- a/pylsp/plugins/pyflakes_lint.py
+++ b/pylsp/plugins/pyflakes_lint.py
@@ -32,11 +32,11 @@ def pylsp_lint(workspace, document):
 
 
 class PyflakesDiagnosticReport:
-    def __init__(self, lines):
+    def __init__(self, lines) -> None:
         self.lines = lines
         self.diagnostics = []
 
-    def unexpectedError(self, _filename, msg):  # pragma: no cover
+    def unexpectedError(self, _filename, msg) -> None:  # pragma: no cover
         err_range = {
             "start": {"line": 0, "character": 0},
             "end": {"line": 0, "character": 0},
@@ -50,7 +50,7 @@ class PyflakesDiagnosticReport:
             }
         )
 
-    def syntaxError(self, _filename, msg, lineno, offset, text):
+    def syntaxError(self, _filename, msg, lineno, offset, text) -> None:
         # We've seen that lineno and offset can sometimes be None
         lineno = lineno or 1
         offset = offset or 0
@@ -71,7 +71,7 @@ class PyflakesDiagnosticReport:
             }
         )
 
-    def flake(self, message):
+    def flake(self, message) -> None:
         """Get message like <filename>:<lineno>: <msg>"""
         err_range = {
             "start": {"line": message.lineno - 1, "character": message.col},

--- a/pylsp/plugins/rope_autoimport.py
+++ b/pylsp/plugins/rope_autoimport.py
@@ -29,7 +29,7 @@ MAX_RESULTS_CODE_ACTIONS = 5
 class AutoimportCache:
     """Handles the cache creation."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.thread = None
 
     def reload_cache(
@@ -66,7 +66,7 @@ class AutoimportCache:
         workspace: Workspace,
         autoimport: AutoImport,
         resources: Optional[List[Resource]] = None,
-    ):
+    ) -> None:
         task_handle = PylspTaskHandle(workspace)
         autoimport.generate_cache(task_handle=task_handle, resources=resources)
         autoimport.generate_modules_cache(task_handle=task_handle)
@@ -365,7 +365,7 @@ def pylsp_code_actions(
 
 
 @hookimpl
-def pylsp_initialize(config: Config, workspace: Workspace):
+def pylsp_initialize(config: Config, workspace: Workspace) -> None:
     """Initialize AutoImport.
 
     Generates the cache for local and global items.
@@ -374,7 +374,7 @@ def pylsp_initialize(config: Config, workspace: Workspace):
 
 
 @hookimpl
-def pylsp_document_did_open(config: Config, workspace: Workspace):
+def pylsp_document_did_open(config: Config, workspace: Workspace) -> None:
     """Initialize AutoImport.
 
     Generates the cache for local and global items.
@@ -383,13 +383,13 @@ def pylsp_document_did_open(config: Config, workspace: Workspace):
 
 
 @hookimpl
-def pylsp_document_did_save(config: Config, workspace: Workspace, document: Document):
+def pylsp_document_did_save(config: Config, workspace: Workspace, document: Document) -> None:
     """Update the names associated with this document."""
     cache.reload_cache(config, workspace, [document])
 
 
 @hookimpl
-def pylsp_workspace_configuration_changed(config: Config, workspace: Workspace):
+def pylsp_workspace_configuration_changed(config: Config, workspace: Workspace) -> None:
     """
     Initialize autoimport if it has been enabled through a
     workspace/didChangeConfiguration message from the frontend.

--- a/pylsp/plugins/rope_autoimport.py
+++ b/pylsp/plugins/rope_autoimport.py
@@ -383,7 +383,9 @@ def pylsp_document_did_open(config: Config, workspace: Workspace) -> None:
 
 
 @hookimpl
-def pylsp_document_did_save(config: Config, workspace: Workspace, document: Document) -> None:
+def pylsp_document_did_save(
+    config: Config, workspace: Workspace, document: Document
+) -> None:
     """Update the names associated with this document."""
     cache.reload_cache(config, workspace, [document])
 

--- a/pylsp/python_lsp.py
+++ b/pylsp/python_lsp.py
@@ -448,7 +448,9 @@ class PythonLSPServer(MethodDispatcher):
         elif isinstance(document_object, Notebook):
             self._lint_notebook_document(document_object, workspace)
 
-    def _lint_text_document(self, doc_uri, workspace, is_saved, doc_version=None) -> None:
+    def _lint_text_document(
+        self, doc_uri, workspace, is_saved, doc_version=None
+    ) -> None:
         workspace.publish_diagnostics(
             doc_uri,
             flatten(self._hook("pylsp_lint", doc_uri, is_saved=is_saved)),

--- a/pylsp/python_lsp.py
+++ b/pylsp/python_lsp.py
@@ -38,11 +38,11 @@ class _StreamHandlerWrapper(socketserver.StreamRequestHandler):
 
     delegate = None
 
-    def setup(self):
+    def setup(self) -> None:
         super().setup()
         self.delegate = self.DELEGATE_CLASS(self.rfile, self.wfile)
 
-    def handle(self):
+    def handle(self) -> None:
         try:
             self.delegate.start()
         except OSError as e:
@@ -55,7 +55,7 @@ class _StreamHandlerWrapper(socketserver.StreamRequestHandler):
         self.SHUTDOWN_CALL()
 
 
-def start_tcp_lang_server(bind_addr, port, check_parent_process, handler_class):
+def start_tcp_lang_server(bind_addr, port, check_parent_process, handler_class) -> None:
     if not issubclass(handler_class, PythonLSPServer):
         raise ValueError("Handler class must be an instance of PythonLSPServer")
 
@@ -93,7 +93,7 @@ def start_tcp_lang_server(bind_addr, port, check_parent_process, handler_class):
         server.server_close()
 
 
-def start_io_lang_server(rfile, wfile, check_parent_process, handler_class):
+def start_io_lang_server(rfile, wfile, check_parent_process, handler_class) -> None:
     if not issubclass(handler_class, PythonLSPServer):
         raise ValueError("Handler class must be an instance of PythonLSPServer")
     log.info("Starting %s IO language server", handler_class.__name__)
@@ -101,7 +101,7 @@ def start_io_lang_server(rfile, wfile, check_parent_process, handler_class):
     server.start()
 
 
-def start_ws_lang_server(port, check_parent_process, handler_class):
+def start_ws_lang_server(port, check_parent_process, handler_class) -> None:
     if not issubclass(handler_class, PythonLSPServer):
         raise ValueError("Handler class must be an instance of PythonLSPServer")
 
@@ -165,7 +165,7 @@ class PythonLSPServer(MethodDispatcher):
 
     def __init__(
         self, rx, tx, check_parent_process=False, consumer=None, *, endpoint_cls=None
-    ):
+    ) -> None:
         self.workspace = None
         self.config = None
         self.root_uri = None
@@ -198,11 +198,11 @@ class PythonLSPServer(MethodDispatcher):
         self._dispatchers = []
         self._shutdown = False
 
-    def start(self):
+    def start(self) -> None:
         """Entry point for the server."""
         self._jsonrpc_stream_reader.listen(self._endpoint.consume)
 
-    def consume(self, message):
+    def consume(self, message) -> None:
         """Entry point for consumer based server. Alternative to stream listeners."""
         # assuming message will be JSON
         self._endpoint.consume(message)
@@ -226,7 +226,7 @@ class PythonLSPServer(MethodDispatcher):
 
         raise KeyError()
 
-    def m_shutdown(self, **_kwargs):
+    def m_shutdown(self, **_kwargs) -> None:
         for workspace in self.workspaces.values():
             workspace.close()
         self._shutdown = True
@@ -239,7 +239,7 @@ class PythonLSPServer(MethodDispatcher):
             }
         }
 
-    def m_exit(self, **_kwargs):
+    def m_exit(self, **_kwargs) -> None:
         self._endpoint.shutdown()
         if self._jsonrpc_stream_reader is not None:
             self._jsonrpc_stream_reader.close()
@@ -379,7 +379,7 @@ class PythonLSPServer(MethodDispatcher):
             },
         }
 
-    def m_initialized(self, **_kwargs):
+    def m_initialized(self, **_kwargs) -> None:
         self._hook("pylsp_initialized")
 
     def code_actions(self, doc_uri: str, range: Dict, context: Dict):
@@ -437,7 +437,7 @@ class PythonLSPServer(MethodDispatcher):
         return self._hook("pylsp_hover", doc_uri, position=position) or {"contents": ""}
 
     @_utils.debounce(LINT_DEBOUNCE_S, keyed_by="doc_uri")
-    def lint(self, doc_uri, is_saved):
+    def lint(self, doc_uri, is_saved) -> None:
         # Since we're debounced, the document may no longer be open
         workspace = self._match_uri_to_workspace(doc_uri)
         document_object = workspace.documents.get(doc_uri, None)
@@ -446,12 +446,12 @@ class PythonLSPServer(MethodDispatcher):
         elif isinstance(document_object, Notebook):
             self._lint_notebook_document(document_object, workspace)
 
-    def _lint_text_document(self, doc_uri, workspace, is_saved):
+    def _lint_text_document(self, doc_uri, workspace, is_saved) -> None:
         workspace.publish_diagnostics(
             doc_uri, flatten(self._hook("pylsp_lint", doc_uri, is_saved=is_saved))
         )
 
-    def _lint_notebook_document(self, notebook_document, workspace):
+    def _lint_notebook_document(self, notebook_document, workspace) -> None:
         """
         Lint a notebook document.
 
@@ -541,7 +541,7 @@ class PythonLSPServer(MethodDispatcher):
 
     def m_notebook_document__did_open(
         self, notebookDocument=None, cellTextDocuments=None, **_kwargs
-    ):
+    ) -> None:
         workspace = self._match_uri_to_workspace(notebookDocument["uri"])
         workspace.put_notebook_document(
             notebookDocument["uri"],
@@ -562,7 +562,7 @@ class PythonLSPServer(MethodDispatcher):
 
     def m_notebook_document__did_close(
         self, notebookDocument=None, cellTextDocuments=None, **_kwargs
-    ):
+    ) -> None:
         workspace = self._match_uri_to_workspace(notebookDocument["uri"])
         for cell in cellTextDocuments or []:
             workspace.publish_diagnostics(cell["uri"], [])
@@ -571,7 +571,7 @@ class PythonLSPServer(MethodDispatcher):
 
     def m_notebook_document__did_change(
         self, notebookDocument=None, change=None, **_kwargs
-    ):
+    ) -> None:
         """
         Changes to the notebook document.
 
@@ -645,12 +645,12 @@ class PythonLSPServer(MethodDispatcher):
                     workspace.update_document(cell_uri, cell["changes"][0])
         self.lint(notebookDocument["uri"], is_saved=True)
 
-    def m_text_document__did_close(self, textDocument=None, **_kwargs):
+    def m_text_document__did_close(self, textDocument=None, **_kwargs) -> None:
         workspace = self._match_uri_to_workspace(textDocument["uri"])
         workspace.publish_diagnostics(textDocument["uri"], [])
         workspace.rm_document(textDocument["uri"])
 
-    def m_text_document__did_open(self, textDocument=None, **_kwargs):
+    def m_text_document__did_open(self, textDocument=None, **_kwargs) -> None:
         workspace = self._match_uri_to_workspace(textDocument["uri"])
         workspace.put_document(
             textDocument["uri"],
@@ -662,7 +662,7 @@ class PythonLSPServer(MethodDispatcher):
 
     def m_text_document__did_change(
         self, contentChanges=None, textDocument=None, **_kwargs
-    ):
+    ) -> None:
         workspace = self._match_uri_to_workspace(textDocument["uri"])
         for change in contentChanges:
             workspace.update_document(
@@ -670,7 +670,7 @@ class PythonLSPServer(MethodDispatcher):
             )
         self.lint(textDocument["uri"], is_saved=False)
 
-    def m_text_document__did_save(self, textDocument=None, **_kwargs):
+    def m_text_document__did_save(self, textDocument=None, **_kwargs) -> None:
         self.lint(textDocument["uri"], is_saved=True)
         self.document_did_save(textDocument["uri"])
 
@@ -794,7 +794,7 @@ class PythonLSPServer(MethodDispatcher):
     ):
         return self.signature_help(textDocument["uri"], position)
 
-    def m_workspace__did_change_configuration(self, settings=None):
+    def m_workspace__did_change_configuration(self, settings=None) -> None:
         if self.config is not None:
             self.config.update((settings or {}).get("pylsp", {}))
         for workspace in self.workspaces.values():

--- a/pylsp/workspace.py
+++ b/pylsp/workspace.py
@@ -42,7 +42,7 @@ class Workspace:
     M_APPLY_EDIT = "workspace/applyEdit"
     M_SHOW_MESSAGE = "window/showMessage"
 
-    def __init__(self, root_uri, endpoint, config=None):
+    def __init__(self, root_uri, endpoint, config=None) -> None:
         self._config = config
         self._root_uri = root_uri
         self._endpoint = endpoint
@@ -118,20 +118,20 @@ class Workspace:
     def get_maybe_document(self, doc_uri):
         return self._docs.get(doc_uri)
 
-    def put_document(self, doc_uri, source, version=None):
+    def put_document(self, doc_uri, source, version=None) -> None:
         self._docs[doc_uri] = self._create_document(
             doc_uri, source=source, version=version
         )
 
     def put_notebook_document(
         self, doc_uri, notebook_type, cells, version=None, metadata=None
-    ):
+    ) -> None:
         self._docs[doc_uri] = self._create_notebook_document(
             doc_uri, notebook_type, cells, version, metadata
         )
 
     @contextmanager
-    def temp_document(self, source, path=None):
+    def temp_document(self, source, path=None) -> None:
         if path is None:
             path = self.root_path
         uri = uris.from_fs_path(os.path.join(path, str(uuid.uuid4())))
@@ -141,26 +141,26 @@ class Workspace:
         finally:
             self.rm_document(uri)
 
-    def add_notebook_cells(self, doc_uri, cells, start):
+    def add_notebook_cells(self, doc_uri, cells, start) -> None:
         self._docs[doc_uri].add_cells(cells, start)
 
-    def remove_notebook_cells(self, doc_uri, start, delete_count):
+    def remove_notebook_cells(self, doc_uri, start, delete_count) -> None:
         self._docs[doc_uri].remove_cells(start, delete_count)
 
-    def update_notebook_metadata(self, doc_uri, metadata):
+    def update_notebook_metadata(self, doc_uri, metadata) -> None:
         self._docs[doc_uri].metadata = metadata
 
     def put_cell_document(
         self, doc_uri, notebook_uri, language_id, source, version=None
-    ):
+    ) -> None:
         self._docs[doc_uri] = self._create_cell_document(
             doc_uri, notebook_uri, language_id, source, version
         )
 
-    def rm_document(self, doc_uri):
+    def rm_document(self, doc_uri) -> None:
         self._docs.pop(doc_uri)
 
-    def update_document(self, doc_uri, change, version=None):
+    def update_document(self, doc_uri, change, version=None) -> None:
         self._docs[doc_uri].apply_change(change)
         self._docs[doc_uri].version = version
 
@@ -176,7 +176,7 @@ class Workspace:
     def apply_edit(self, edit):
         return self._endpoint.request(self.M_APPLY_EDIT, {"edit": edit})
 
-    def publish_diagnostics(self, doc_uri, diagnostics):
+    def publish_diagnostics(self, doc_uri, diagnostics) -> None:
         self._endpoint.notify(
             self.M_PUBLISH_DIAGNOSTICS,
             params={"uri": doc_uri, "diagnostics": diagnostics},
@@ -316,7 +316,7 @@ class Workspace:
             },
         )
 
-    def show_message(self, message, msg_type=lsp.MessageType.Info):
+    def show_message(self, message, msg_type=lsp.MessageType.Info) -> None:
         self._endpoint.notify(
             self.M_SHOW_MESSAGE, params={"type": msg_type, "message": message}
         )
@@ -372,7 +372,7 @@ class Workspace:
             rope_project_builder=self._rope_project_builder,
         )
 
-    def close(self):
+    def close(self) -> None:
         if self.__rope_autoimport:
             self.__rope_autoimport.close()
 
@@ -387,7 +387,7 @@ class Document:
         local=True,
         extra_sys_path=None,
         rope_project_builder=None,
-    ):
+    ) -> None:
         self.uri = uri
         self.version = version
         self.path = uris.to_fs_path(uri)
@@ -426,7 +426,7 @@ class Document:
                 return f.read()
         return self._source
 
-    def update_config(self, settings):
+    def update_config(self, settings) -> None:
         self._config.update((settings or {}).get("pylsp", {}))
 
     @lock
@@ -586,7 +586,7 @@ class Notebook:
 
     def __init__(
         self, uri, notebook_type, workspace, cells=None, version=None, metadata=None
-    ):
+    ) -> None:
         self.uri = uri
         self.notebook_type = notebook_type
         self.workspace = workspace
@@ -671,7 +671,7 @@ class Cell(Document):
         local=True,
         extra_sys_path=None,
         rope_project_builder=None,
-    ):
+    ) -> None:
         super().__init__(
             uri, workspace, source, version, local, extra_sys_path, rope_project_builder
         )

--- a/scripts/jsonschema2md.py
+++ b/scripts/jsonschema2md.py
@@ -73,7 +73,7 @@ def convert_schema(schema: dict, source: str = None) -> str:
     return "\n".join(lines)
 
 
-def main(argv):
+def main(argv) -> None:
     parser = ArgumentParser()
     parser.add_argument("schema", type=FileType())
     parser.add_argument("markdown", type=FileType("w+"), default=sys.stdout)

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -112,7 +112,7 @@ def endpoint(consumer):
 
 
 @pytest.fixture
-def workspace(tmpdir, endpoint):
+def workspace(tmpdir, endpoint) -> None:
     """Return a workspace."""
     ws = Workspace(uris.from_fs_path(str(tmpdir)), endpoint)
     ws._config = Config(ws.root_uri, {}, 0, {})
@@ -166,7 +166,7 @@ def temp_workspace_factory(workspace):
 
 
 @pytest.fixture
-def client_server_pair():
+def client_server_pair() -> None:
     """A fixture that sets up a client/server pair and shuts down the server"""
     client_server_pair_obj = ClientServerPair()
 

--- a/test/plugins/test_autoimport.py
+++ b/test/plugins/test_autoimport.py
@@ -61,7 +61,7 @@ def autoimport_workspace(tmp_path_factory) -> Workspace:
 
 
 @pytest.fixture
-def completions(config: Config, autoimport_workspace: Workspace, request):
+def completions(config: Config, autoimport_workspace: Workspace, request) -> None:
     document, position = request.param
     com_position = {"line": 0, "character": position}
     autoimport_workspace.put_document(DOC_URI, source=document)
@@ -86,7 +86,7 @@ def check_dict(query: Dict, results: List[Dict]) -> bool:
 
 
 @pytest.mark.parametrize("completions", [("""pathli """, 6)], indirect=True)
-def test_autoimport_completion(completions):
+def test_autoimport_completion(completions) -> None:
     assert completions
     assert check_dict(
         {"label": "pathlib", "kind": lsp.CompletionItemKind.Module}, completions
@@ -94,12 +94,12 @@ def test_autoimport_completion(completions):
 
 
 @pytest.mark.parametrize("completions", [("""import """, 7)], indirect=True)
-def test_autoimport_import(completions):
+def test_autoimport_import(completions) -> None:
     assert len(completions) == 0
 
 
 @pytest.mark.parametrize("completions", [("""pathlib""", 2)], indirect=True)
-def test_autoimport_pathlib(completions):
+def test_autoimport_pathlib(completions) -> None:
     assert completions[0]["label"] == "pathlib"
 
     start = {"line": 0, "character": 0}
@@ -110,41 +110,41 @@ def test_autoimport_pathlib(completions):
 
 
 @pytest.mark.parametrize("completions", [("""import test\n""", 10)], indirect=True)
-def test_autoimport_import_with_name(completions):
+def test_autoimport_import_with_name(completions) -> None:
     assert len(completions) == 0
 
 
 @pytest.mark.parametrize("completions", [("""def func(s""", 10)], indirect=True)
-def test_autoimport_function(completions):
+def test_autoimport_function(completions) -> None:
     assert len(completions) == 0
 
 
 @pytest.mark.parametrize("completions", [("""class Test""", 10)], indirect=True)
-def test_autoimport_class(completions):
+def test_autoimport_class(completions) -> None:
     assert len(completions) == 0
 
 
 @pytest.mark.parametrize("completions", [("""\n""", 0)], indirect=True)
-def test_autoimport_empty_line(completions):
+def test_autoimport_empty_line(completions) -> None:
     assert len(completions) == 0
 
 
 @pytest.mark.parametrize(
     "completions", [("""class Test(NamedTupl):""", 20)], indirect=True
 )
-def test_autoimport_class_complete(completions):
+def test_autoimport_class_complete(completions) -> None:
     assert len(completions) > 0
 
 
 @pytest.mark.parametrize(
     "completions", [("""class Test(NamedTupl""", 20)], indirect=True
 )
-def test_autoimport_class_incomplete(completions):
+def test_autoimport_class_incomplete(completions) -> None:
     assert len(completions) > 0
 
 
 @pytest.mark.parametrize("completions", [("""def func(s:Lis""", 12)], indirect=True)
-def test_autoimport_function_typing(completions):
+def test_autoimport_function_typing(completions) -> None:
     assert len(completions) > 0
     assert check_dict({"label": "List"}, completions)
 
@@ -152,7 +152,7 @@ def test_autoimport_function_typing(completions):
 @pytest.mark.parametrize(
     "completions", [("""def func(s : Lis ):""", 16)], indirect=True
 )
-def test_autoimport_function_typing_complete(completions):
+def test_autoimport_function_typing_complete(completions) -> None:
     assert len(completions) > 0
     assert check_dict({"label": "List"}, completions)
 
@@ -160,12 +160,12 @@ def test_autoimport_function_typing_complete(completions):
 @pytest.mark.parametrize(
     "completions", [("""def func(s : Lis ) -> Generat:""", 29)], indirect=True
 )
-def test_autoimport_function_typing_return(completions):
+def test_autoimport_function_typing_return(completions) -> None:
     assert len(completions) > 0
     assert check_dict({"label": "Generator"}, completions)
 
 
-def test_autoimport_defined_name(config, workspace):
+def test_autoimport_defined_name(config, workspace) -> None:
     document = """List = "hi"\nLis"""
     com_position = {"line": 1, "character": 3}
     workspace.put_document(DOC_URI, source=document)
@@ -178,30 +178,30 @@ def test_autoimport_defined_name(config, workspace):
 
 
 class TestShouldInsert:
-    def test_dot(self):
+    def test_dot(self) -> None:
         assert not should_insert("""str.""", 4)
 
-    def test_dot_partial(self):
+    def test_dot_partial(self) -> None:
         assert not should_insert("""str.metho\n""", 9)
 
-    def test_comment(self):
+    def test_comment(self) -> None:
         assert not should_insert("""#""", 1)
 
-    def test_comment_indent(self):
+    def test_comment_indent(self) -> None:
         assert not should_insert("""    # """, 5)
 
-    def test_from(self):
+    def test_from(self) -> None:
         assert not should_insert("""from """, 5)
         assert should_insert("""from """, 4)
 
 
-def test_sort_sources():
+def test_sort_sources() -> None:
     result1 = _get_score(1, "import pathlib", "pathlib", "pathli")
     result2 = _get_score(2, "import pathlib", "pathlib", "pathli")
     assert result1 < result2
 
 
-def test_sort_statements():
+def test_sort_statements() -> None:
     result1 = _get_score(
         2, "from importlib_metadata import pathlib", "pathlib", "pathli"
     )
@@ -209,7 +209,7 @@ def test_sort_statements():
     assert result1 > result2
 
 
-def test_sort_both():
+def test_sort_both() -> None:
     result1 = _get_score(
         3, "from importlib_metadata import pathlib", "pathlib", "pathli"
     )
@@ -217,7 +217,7 @@ def test_sort_both():
     assert result1 > result2
 
 
-def test_get_names():
+def test_get_names() -> None:
     source = """
     from a import s as e
     import blah, bleh
@@ -237,7 +237,7 @@ def test_get_names():
     "message",
     ["Undefined name `os`", "F821 undefined name 'numpy'", "undefined name 'numpy'"],
 )
-def test_autoimport_code_actions_get_correct_module_name(autoimport_workspace, message):
+def test_autoimport_code_actions_get_correct_module_name(autoimport_workspace, message) -> None:
     source = "os.path.join('a', 'b')"
     autoimport_workspace.put_document(DOC_URI, source=source)
     doc = autoimport_workspace.get_document(DOC_URI)
@@ -274,7 +274,7 @@ def position(line, character):
 @pytest.mark.skipif(IS_WIN, reason="Flaky on Windows")
 def test_autoimport_code_actions_and_completions_for_notebook_document(
     client_server_pair,
-):
+) -> None:
     client, server = client_server_pair
     send_initialize_request(
         client,

--- a/test/plugins/test_autoimport.py
+++ b/test/plugins/test_autoimport.py
@@ -237,7 +237,9 @@ def test_get_names() -> None:
     "message",
     ["Undefined name `os`", "F821 undefined name 'numpy'", "undefined name 'numpy'"],
 )
-def test_autoimport_code_actions_get_correct_module_name(autoimport_workspace, message) -> None:
+def test_autoimport_code_actions_get_correct_module_name(
+    autoimport_workspace, message
+) -> None:
     source = "os.path.join('a', 'b')"
     autoimport_workspace.put_document(DOC_URI, source=source)
     doc = autoimport_workspace.get_document(DOC_URI)

--- a/test/plugins/test_autopep8_format.py
+++ b/test/plugins/test_autopep8_format.py
@@ -39,7 +39,7 @@ bar = {'foo': foo
 """
 
 
-def test_format(config, workspace):
+def test_format(config, workspace) -> None:
     doc = Document(DOC_URI, workspace, DOC)
     res = pylsp_format_document(config, workspace, doc, options=None)
 
@@ -47,7 +47,7 @@ def test_format(config, workspace):
     assert res[0]["newText"] == "a = 123\n\n\ndef func():\n    pass\n"
 
 
-def test_range_format(config, workspace):
+def test_range_format(config, workspace) -> None:
     doc = Document(DOC_URI, workspace, DOC)
 
     def_range = {
@@ -62,12 +62,12 @@ def test_range_format(config, workspace):
     assert res[0]["newText"] == "a = 123\n\n\n\n\ndef func():\n    pass\n"
 
 
-def test_no_change(config, workspace):
+def test_no_change(config, workspace) -> None:
     doc = Document(DOC_URI, workspace, GOOD_DOC)
     assert not pylsp_format_document(config, workspace, doc, options=None)
 
 
-def test_hanging_indentation(config, workspace):
+def test_hanging_indentation(config, workspace) -> None:
     doc = Document(DOC_URI, workspace, INDENTED_DOC)
     res = pylsp_format_document(config, workspace, doc, options=None)
 
@@ -76,7 +76,7 @@ def test_hanging_indentation(config, workspace):
 
 
 @pytest.mark.parametrize("newline", ["\r\n", "\r"])
-def test_line_endings(config, workspace, newline):
+def test_line_endings(config, workspace, newline) -> None:
     doc = Document(DOC_URI, workspace, f"import os;import sys{2 * newline}dict(a=1)")
     res = pylsp_format_document(config, workspace, doc, options=None)
 

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -51,7 +51,7 @@ def documented_hello():
 """
 
 
-def test_rope_import_completion(config, workspace):
+def test_rope_import_completion(config, workspace) -> None:
     com_position = {"line": 0, "character": 7}
     doc = Document(DOC_URI, workspace, DOC)
     items = pylsp_rope_completions(config, workspace, doc, com_position)
@@ -131,7 +131,7 @@ def test_jedi_completion_type(case, config, workspace):
     assert items[case.label]["kind"] == case.expected
 
 
-def test_jedi_completion(config, workspace):
+def test_jedi_completion(config, workspace) -> None:
     # Over 'i' in os.path.isabs(...)
     com_position = {"line": 1, "character": 15}
     doc = Document(DOC_URI, workspace, DOC)
@@ -145,7 +145,7 @@ def test_jedi_completion(config, workspace):
     pylsp_jedi_completions(config, doc, {"line": 1, "character": 1000})
 
 
-def test_jedi_completion_item_resolve(config, workspace):
+def test_jedi_completion_item_resolve(config, workspace) -> None:
     # Over the blank line
     com_position = {"line": 8, "character": 0}
     doc = Document(DOC_URI, workspace, DOC)
@@ -169,7 +169,7 @@ def test_jedi_completion_item_resolve(config, workspace):
     assert resolved_documented_hello["documentation"] == expected_doc
 
 
-def test_jedi_completion_with_fuzzy_enabled(config, workspace):
+def test_jedi_completion_with_fuzzy_enabled(config, workspace) -> None:
     # Over 'i' in os.path.isabs(...)
     config.update({"plugins": {"jedi_completion": {"fuzzy": True}}})
     com_position = {"line": 1, "character": 15}
@@ -188,7 +188,7 @@ def test_jedi_completion_with_fuzzy_enabled(config, workspace):
     pylsp_jedi_completions(config, doc, {"line": 1, "character": 1000})
 
 
-def test_jedi_completion_resolve_at_most(config, workspace):
+def test_jedi_completion_resolve_at_most(config, workspace) -> None:
     # Over 'i' in os.path.isabs(...)
     com_position = {"line": 1, "character": 15}
     doc = Document(DOC_URI, workspace, DOC)
@@ -206,7 +206,7 @@ def test_jedi_completion_resolve_at_most(config, workspace):
     assert "isfile(path)" in labels
 
 
-def test_rope_completion(config, workspace):
+def test_rope_completion(config, workspace) -> None:
     # Over 'i' in os.path.isabs(...)
     com_position = {"line": 1, "character": 15}
     workspace.put_document(DOC_URI, source=DOC)
@@ -217,7 +217,7 @@ def test_rope_completion(config, workspace):
     assert items[0]["label"] == "isabs"
 
 
-def test_jedi_completion_ordering(config, workspace):
+def test_jedi_completion_ordering(config, workspace) -> None:
     # Over the blank line
     com_position = {"line": 8, "character": 0}
     doc = Document(DOC_URI, workspace, DOC)
@@ -230,7 +230,7 @@ def test_jedi_completion_ordering(config, workspace):
     assert items["hello()"] < items["_a_hello()"]
 
 
-def test_jedi_property_completion(config, workspace):
+def test_jedi_property_completion(config, workspace) -> None:
     # Over the 'w' in 'print Hello().world'
     com_position = {"line": 18, "character": 15}
     doc = Document(DOC_URI, workspace, DOC)
@@ -242,7 +242,7 @@ def test_jedi_property_completion(config, workspace):
     assert "world" in list(items.keys())[0]
 
 
-def test_jedi_method_completion(config, workspace):
+def test_jedi_method_completion(config, workspace) -> None:
     # Over the 'y' in 'print Hello().every'
     com_position = {"line": 20, "character": 19}
     doc = Document(DOC_URI, workspace, DOC)
@@ -281,7 +281,7 @@ def test_jedi_method_completion(config, workspace):
     PY2 or (sys.platform.startswith("linux") and os.environ.get("CI") is not None),
     reason="Test in Python 3 and not on CIs on Linux because wheels don't work on them.",
 )
-def test_pyqt_completion(config, workspace):
+def test_pyqt_completion(config, workspace) -> None:
     # Over 'QA' in 'from PyQt5.QtWidgets import QApplication'
     doc_pyqt = "from PyQt5.QtWidgets import QA"
     com_position = {"line": 0, "character": len(doc_pyqt)}
@@ -291,7 +291,7 @@ def test_pyqt_completion(config, workspace):
     assert completions is not None
 
 
-def test_numpy_completions(config, workspace):
+def test_numpy_completions(config, workspace) -> None:
     doc_numpy = "import numpy as np; np."
     com_position = {"line": 0, "character": len(doc_numpy)}
     doc = Document(DOC_URI, workspace, doc_numpy)
@@ -301,7 +301,7 @@ def test_numpy_completions(config, workspace):
     assert any("array" in i["label"] for i in items)
 
 
-def test_pandas_completions(config, workspace):
+def test_pandas_completions(config, workspace) -> None:
     doc_pandas = "import pandas as pd; pd."
     com_position = {"line": 0, "character": len(doc_pandas)}
     doc = Document(DOC_URI, workspace, doc_pandas)
@@ -311,7 +311,7 @@ def test_pandas_completions(config, workspace):
     assert any("DataFrame" in i["label"] for i in items)
 
 
-def test_matplotlib_completions(config, workspace):
+def test_matplotlib_completions(config, workspace) -> None:
     doc_mpl = "import matplotlib.pyplot as plt; plt."
     com_position = {"line": 0, "character": len(doc_mpl)}
     doc = Document(DOC_URI, workspace, doc_mpl)
@@ -321,7 +321,7 @@ def test_matplotlib_completions(config, workspace):
     assert any("plot" in i["label"] for i in items)
 
 
-def test_snippets_completion(config, workspace):
+def test_snippets_completion(config, workspace) -> None:
     doc_snippets = "from collections import defaultdict \na=defaultdict"
     com_position = {"line": 0, "character": 35}
     doc = Document(DOC_URI, workspace, doc_snippets)
@@ -338,7 +338,7 @@ def test_snippets_completion(config, workspace):
     assert completions[0]["insertTextFormat"] == lsp.InsertTextFormat.Snippet
 
 
-def test_snippets_completion_at_most(config, workspace):
+def test_snippets_completion_at_most(config, workspace) -> None:
     doc_snippets = "from collections import defaultdict \na=defaultdict"
     doc = Document(DOC_URI, workspace, doc_snippets)
     config.capabilities["textDocument"] = {
@@ -353,7 +353,7 @@ def test_snippets_completion_at_most(config, workspace):
     assert not completions[0].get("insertTextFormat", None)
 
 
-def test_completion_with_class_objects(config, workspace):
+def test_completion_with_class_objects(config, workspace) -> None:
     doc_text = "class FOOBAR(Object): pass\nFOOB"
     com_position = {"line": 1, "character": 4}
     doc = Document(DOC_URI, workspace, doc_text)
@@ -380,7 +380,7 @@ def test_completion_with_class_objects(config, workspace):
     assert completions[1]["kind"] == lsp.CompletionItemKind.TypeParameter
 
 
-def test_completion_with_function_objects(config, workspace):
+def test_completion_with_function_objects(config, workspace) -> None:
     doc_text = "def foobar(): pass\nfoob"
     com_position = {"line": 1, "character": 4}
     doc = Document(DOC_URI, workspace, doc_text)
@@ -407,7 +407,7 @@ def test_completion_with_function_objects(config, workspace):
     assert completions[1]["kind"] == lsp.CompletionItemKind.TypeParameter
 
 
-def test_snippet_parsing(config, workspace):
+def test_snippet_parsing(config, workspace) -> None:
     doc = "divmod"
     completion_position = {"line": 0, "character": 6}
     doc = Document(DOC_URI, workspace, doc)
@@ -423,7 +423,7 @@ def test_snippet_parsing(config, workspace):
     assert completions[0]["insertText"] == out
 
 
-def test_multiline_import_snippets(config, workspace):
+def test_multiline_import_snippets(config, workspace) -> None:
     document = "from datetime import(\n date,\n datetime)\na=date"
     doc = Document(DOC_URI, workspace, document)
     config.capabilities["textDocument"] = {
@@ -440,7 +440,7 @@ def test_multiline_import_snippets(config, workspace):
     assert completions[0]["insertText"] == "datetime"
 
 
-def test_multiline_snippets(config, workspace):
+def test_multiline_snippets(config, workspace) -> None:
     document = "from datetime import\\\n date,\\\n datetime \na=date"
     doc = Document(DOC_URI, workspace, document)
     config.capabilities["textDocument"] = {
@@ -457,7 +457,7 @@ def test_multiline_snippets(config, workspace):
     assert completions[0]["insertText"] == "datetime"
 
 
-def test_multistatement_snippet(config, workspace):
+def test_multistatement_snippet(config, workspace) -> None:
     config.capabilities["textDocument"] = {
         "completion": {"completionItem": {"snippetSupport": True}}
     }
@@ -476,7 +476,7 @@ def test_multistatement_snippet(config, workspace):
     assert completions[0]["insertText"] == "fmod(${1:x}, ${2:y})$0"
 
 
-def test_jedi_completion_extra_paths(tmpdir, workspace):
+def test_jedi_completion_extra_paths(tmpdir, workspace) -> None:
     # Create a tempfile with some content and pass to extra_paths
     temp_doc_content = """
 def spam():
@@ -510,7 +510,7 @@ foo.s"""
 @pytest.mark.skipif(
     PY2 or not LINUX or not CI, reason="tested on linux and python 3 only"
 )
-def test_jedi_completion_environment(workspace):
+def test_jedi_completion_environment(workspace) -> None:
     # Content of doc to test completion
     doc_content = """import logh
 """
@@ -539,7 +539,7 @@ def test_jedi_completion_environment(workspace):
     assert "changelog generator" in resolved["documentation"]["value"].lower()
 
 
-def test_document_path_completions(tmpdir, workspace_other_root_path):
+def test_document_path_completions(tmpdir, workspace_other_root_path) -> None:
     # Create a dummy module out of the workspace's root_path and try to get
     # completions for it in another file placed next to it.
     module_content = """
@@ -562,7 +562,7 @@ mymodule.f"""
     assert completions[0]["label"] == "foo()"
 
 
-def test_file_completions(workspace, tmpdir):
+def test_file_completions(workspace, tmpdir) -> None:
     # Create directory and a file to get completions for them.
     # Note: `tmpdir`` is the root dir of the `workspace` fixture. That's why we use
     # it here.

--- a/test/plugins/test_definitions.py
+++ b/test/plugins/test_definitions.py
@@ -41,7 +41,7 @@ numpy.ones
 """
 
 
-def test_definitions(config, workspace):
+def test_definitions(config, workspace) -> None:
     # Over 'a' in print a
     cursor_pos = {"line": 3, "character": 6}
 
@@ -57,7 +57,7 @@ def test_definitions(config, workspace):
     )
 
 
-def test_indirect_definitions(config, workspace):
+def test_indirect_definitions(config, workspace) -> None:
     # Over 'subscripted_before_reference'
     cursor_pos = {"line": 16, "character": 0}
 
@@ -74,7 +74,7 @@ def test_indirect_definitions(config, workspace):
     )
 
 
-def test_definition_with_multihop_inference_goto(config, workspace):
+def test_definition_with_multihop_inference_goto(config, workspace) -> None:
     # Over 'inception()'
     cursor_pos = {"line": 26, "character": 0}
 
@@ -91,7 +91,7 @@ def test_definition_with_multihop_inference_goto(config, workspace):
     )
 
 
-def test_numpy_definition(config, workspace):
+def test_numpy_definition(config, workspace) -> None:
     # Over numpy.ones
     cursor_pos = {"line": 29, "character": 8}
 
@@ -100,7 +100,7 @@ def test_numpy_definition(config, workspace):
     assert len(defns) > 0, defns
 
 
-def test_builtin_definition(config, workspace):
+def test_builtin_definition(config, workspace) -> None:
     # Over 'i' in dict
     cursor_pos = {"line": 8, "character": 24}
 
@@ -124,7 +124,7 @@ def test_builtin_definition(config, workspace):
     config.update(orig_settings)
 
 
-def test_assignment(config, workspace):
+def test_assignment(config, workspace) -> None:
     # Over 's' in self.members[id]
     cursor_pos = {"line": 11, "character": 19}
 
@@ -140,7 +140,7 @@ def test_assignment(config, workspace):
     )
 
 
-def test_document_path_definitions(config, workspace_other_root_path, tmpdir):
+def test_document_path_definitions(config, workspace_other_root_path, tmpdir) -> None:
     # Create a dummy module out of the workspace's root_path and try to get
     # a definition on it in another file placed next to it.
     module_content = """

--- a/test/plugins/test_flake8_lint.py
+++ b/test/plugins/test_flake8_lint.py
@@ -30,7 +30,7 @@ def temp_document(doc_text, workspace):
     return name, doc
 
 
-def test_flake8_unsaved(workspace):
+def test_flake8_unsaved(workspace) -> None:
     doc = Document("", workspace, DOC)
     diags = flake8_lint.pylsp_lint(workspace, doc)
     msg = "F841 local variable 'a' is assigned to but never used"
@@ -44,7 +44,7 @@ def test_flake8_unsaved(workspace):
     assert unused_var["tags"] == [lsp.DiagnosticTag.Unnecessary]
 
 
-def test_flake8_lint(workspace):
+def test_flake8_lint(workspace) -> None:
     name, doc = temp_document(DOC, workspace)
     try:
         diags = flake8_lint.pylsp_lint(workspace, doc)
@@ -60,7 +60,7 @@ def test_flake8_lint(workspace):
         os.remove(name)
 
 
-def test_flake8_respecting_configuration(workspace):
+def test_flake8_respecting_configuration(workspace) -> None:
     docs = [
         ("src/__init__.py", ""),
         ("src/a.py", DOC),
@@ -122,7 +122,7 @@ def test_flake8_respecting_configuration(workspace):
     ]
 
 
-def test_flake8_config_param(workspace):
+def test_flake8_config_param(workspace) -> None:
     with patch("pylsp.plugins.flake8_lint.Popen") as popen_mock:
         mock_instance = popen_mock.return_value
         mock_instance.communicate.return_value = [bytes(), bytes()]
@@ -135,7 +135,7 @@ def test_flake8_config_param(workspace):
         assert "--config={}".format(flake8_conf) in call_args
 
 
-def test_flake8_executable_param(workspace):
+def test_flake8_executable_param(workspace) -> None:
     with patch("pylsp.plugins.flake8_lint.Popen") as popen_mock:
         mock_instance = popen_mock.return_value
         mock_instance.communicate.return_value = [bytes(), bytes()]
@@ -168,7 +168,7 @@ def get_flake8_cfg_settings(workspace, config_str):
     return workspace._config.plugin_settings("flake8")
 
 
-def test_flake8_multiline(workspace):
+def test_flake8_multiline(workspace) -> None:
     config_str = r"""[flake8]
 exclude =
     blah/,
@@ -206,7 +206,7 @@ exclude =
     os.unlink(os.path.join(workspace.root_path, "setup.cfg"))
 
 
-def test_flake8_per_file_ignores(workspace):
+def test_flake8_per_file_ignores(workspace) -> None:
     config_str = r"""[flake8]
 ignores = F403
 per-file-ignores =
@@ -236,7 +236,7 @@ exclude =
     os.unlink(os.path.join(workspace.root_path, "setup.cfg"))
 
 
-def test_per_file_ignores_alternative_syntax(workspace):
+def test_per_file_ignores_alternative_syntax(workspace) -> None:
     config_str = r"""[flake8]
 per-file-ignores = **/__init__.py:F401,E402
     """

--- a/test/plugins/test_folding.py
+++ b/test/plugins/test_folding.py
@@ -116,7 +116,7 @@ for i in range(0, 3)
 )
 
 
-def test_folding(workspace):
+def test_folding(workspace) -> None:
     doc = Document(DOC_URI, workspace, DOC)
     ranges = pylsp_folding_range(doc)
     expected = [
@@ -160,7 +160,7 @@ def test_folding(workspace):
     assert ranges == expected
 
 
-def test_folding_syntax_error(workspace):
+def test_folding_syntax_error(workspace) -> None:
     doc = Document(DOC_URI, workspace, SYNTAX_ERR)
     ranges = pylsp_folding_range(doc)
     expected = [

--- a/test/plugins/test_highlight.py
+++ b/test/plugins/test_highlight.py
@@ -11,7 +11,7 @@ a.startswith("b")
 """
 
 
-def test_highlight(workspace):
+def test_highlight(workspace) -> None:
     # Over 'a' in a.startswith
     cursor_pos = {"line": 1, "character": 0}
 
@@ -41,7 +41,7 @@ print sys.path
 """
 
 
-def test_sys_highlight(workspace):
+def test_sys_highlight(workspace) -> None:
     cursor_pos = {"line": 0, "character": 8}
 
     doc = Document(DOC_URI, workspace, SYS_DOC)

--- a/test/plugins/test_hover.py
+++ b/test/plugins/test_hover.py
@@ -23,7 +23,7 @@ np.sin
 """
 
 
-def test_numpy_hover(workspace):
+def test_numpy_hover(workspace) -> None:
     # Over the blank line
     no_hov_position = {"line": 1, "character": 0}
     # Over 'numpy' in import numpy as np
@@ -71,7 +71,7 @@ def test_numpy_hover(workspace):
         )
 
 
-def test_hover(workspace):
+def test_hover(workspace) -> None:
     # Over 'main' in def main():
     hov_position = {"line": 2, "character": 6}
     # Over the blank second line
@@ -86,7 +86,7 @@ def test_hover(workspace):
     assert {"contents": ""} == pylsp_hover(doc._config, doc, no_hov_position)
 
 
-def test_document_path_hover(workspace_other_root_path, tmpdir):
+def test_document_path_hover(workspace_other_root_path, tmpdir) -> None:
     # Create a dummy module out of the workspace's root_path and try to get
     # a definition on it in another file placed next to it.
     module_content = '''

--- a/test/plugins/test_jedi_rename.py
+++ b/test/plugins/test_jedi_rename.py
@@ -33,7 +33,7 @@ def tmp_workspace(temp_workspace_factory):
     )
 
 
-def test_jedi_rename(tmp_workspace, config):
+def test_jedi_rename(tmp_workspace, config) -> None:
     # rename the `Test1` class
     position = {"line": 0, "character": 6}
     DOC_URI = uris.from_fs_path(os.path.join(tmp_workspace.root_path, DOC_NAME))

--- a/test/plugins/test_mccabe_lint.py
+++ b/test/plugins/test_mccabe_lint.py
@@ -14,7 +14,7 @@ DOC_SYNTAX_ERR = """def hello()
 \tpass"""
 
 
-def test_mccabe(config, workspace):
+def test_mccabe(config, workspace) -> None:
     old_settings = config.settings
     try:
         config.update({"plugins": {"mccabe": {"threshold": 1}}})
@@ -34,6 +34,6 @@ def test_mccabe(config, workspace):
         config._settings = old_settings
 
 
-def test_mccabe_syntax_error(config, workspace):
+def test_mccabe_syntax_error(config, workspace) -> None:
     doc = Document(DOC_URI, workspace, DOC_SYNTAX_ERR)
     assert mccabe_lint.pylsp_lint(config, workspace, doc) is None

--- a/test/plugins/test_pycodestyle_lint.py
+++ b/test/plugins/test_pycodestyle_lint.py
@@ -24,7 +24,7 @@ import json
 """
 
 
-def test_pycodestyle(workspace):
+def test_pycodestyle(workspace) -> None:
     doc = Document(DOC_URI, workspace, DOC)
     diags = pycodestyle_lint.pylsp_lint(workspace, doc)
 
@@ -64,7 +64,7 @@ def test_pycodestyle(workspace):
     assert mod_import["range"]["end"] == {"line": 5, "character": 10}
 
 
-def test_pycodestyle_config(workspace):
+def test_pycodestyle_config(workspace) -> None:
     """Test that we load config files properly.
 
     Config files are loaded in the following order:
@@ -118,7 +118,7 @@ def test_pycodestyle_config(workspace):
 
 
 @pytest.mark.parametrize("newline", ["\r\n", "\r"])
-def test_line_endings(workspace, newline):
+def test_line_endings(workspace, newline) -> None:
     """
     Check that Pycodestyle doesn't generate false positives with line endings
     other than LF.

--- a/test/plugins/test_pydocstyle_lint.py
+++ b/test/plugins/test_pydocstyle_lint.py
@@ -19,7 +19,7 @@ import json
 """
 
 
-def test_pydocstyle(config, workspace):
+def test_pydocstyle(config, workspace) -> None:
     doc = Document(DOC_URI, workspace, DOC)
     diags = pydocstyle_lint.pylsp_lint(config, workspace, doc)
 
@@ -38,21 +38,21 @@ def test_pydocstyle(config, workspace):
     }
 
 
-def test_pydocstyle_test_document(config, workspace):
+def test_pydocstyle_test_document(config, workspace) -> None:
     # The default --match argument excludes test_* documents.
     doc = Document(TEST_DOC_URI, workspace, "")
     diags = pydocstyle_lint.pylsp_lint(config, workspace, doc)
     assert not diags
 
 
-def test_pydocstyle_empty_source(config, workspace):
+def test_pydocstyle_empty_source(config, workspace) -> None:
     doc = Document(DOC_URI, workspace, "")
     diags = pydocstyle_lint.pylsp_lint(config, workspace, doc)
     assert diags[0]["message"] == "D100: Missing docstring in public module"
     assert len(diags) == 1
 
 
-def test_pydocstyle_invalid_source(config, workspace):
+def test_pydocstyle_invalid_source(config, workspace) -> None:
     doc = Document(DOC_URI, workspace, "bad syntax")
     diags = pydocstyle_lint.pylsp_lint(config, workspace, doc)
     # We're unable to parse the file, so can't get any pydocstyle diagnostics

--- a/test/plugins/test_pyflakes_lint.py
+++ b/test/plugins/test_pyflakes_lint.py
@@ -28,7 +28,7 @@ import sys
 """
 
 
-def test_pyflakes(workspace):
+def test_pyflakes(workspace) -> None:
     doc = Document(DOC_URI, workspace, DOC)
     diags = pyflakes_lint.pylsp_lint(workspace, doc)
 
@@ -40,7 +40,7 @@ def test_pyflakes(workspace):
     assert unused_import["severity"] == lsp.DiagnosticSeverity.Warning
 
 
-def test_syntax_error_pyflakes(workspace):
+def test_syntax_error_pyflakes(workspace) -> None:
     doc = Document(DOC_URI, workspace, DOC_SYNTAX_ERR)
     diag = pyflakes_lint.pylsp_lint(workspace, doc)[0]
 
@@ -52,7 +52,7 @@ def test_syntax_error_pyflakes(workspace):
     assert diag["severity"] == lsp.DiagnosticSeverity.Error
 
 
-def test_undefined_name_pyflakes(workspace):
+def test_undefined_name_pyflakes(workspace) -> None:
     doc = Document(DOC_URI, workspace, DOC_UNDEFINED_NAME_ERR)
     diag = pyflakes_lint.pylsp_lint(workspace, doc)[0]
 
@@ -61,7 +61,7 @@ def test_undefined_name_pyflakes(workspace):
     assert diag["severity"] == lsp.DiagnosticSeverity.Error
 
 
-def test_unicode_encoding(workspace):
+def test_unicode_encoding(workspace) -> None:
     doc = Document(DOC_URI, workspace, DOC_ENCODING)
     diags = pyflakes_lint.pylsp_lint(workspace, doc)
 

--- a/test/plugins/test_pylint_lint.py
+++ b/test/plugins/test_pylint_lint.py
@@ -26,7 +26,7 @@ DOC_SYNTAX_ERR = """def hello()
 
 
 @contextlib.contextmanager
-def temp_document(doc_text, workspace):
+def temp_document(doc_text, workspace) -> None:
     try:
         with tempfile.NamedTemporaryFile(mode="w", delete=False) as temp_file:
             name = temp_file.name
@@ -36,12 +36,12 @@ def temp_document(doc_text, workspace):
         os.remove(name)
 
 
-def write_temp_doc(document, contents):
+def write_temp_doc(document, contents) -> None:
     with open(document.path, "w", encoding="utf-8") as temp_file:
         temp_file.write(contents)
 
 
-def test_pylint(config, workspace):
+def test_pylint(config, workspace) -> None:
     with temp_document(DOC, workspace) as doc:
         diags = pylint_lint.pylsp_lint(config, workspace, doc, True)
 
@@ -66,7 +66,7 @@ def test_pylint(config, workspace):
         assert unused_import["severity"] == lsp.DiagnosticSeverity.Warning
 
 
-def test_syntax_error_pylint(config, workspace):
+def test_syntax_error_pylint(config, workspace) -> None:
     with temp_document(DOC_SYNTAX_ERR, workspace) as doc:
         diag = pylint_lint.pylsp_lint(config, workspace, doc, True)[0]
 
@@ -91,7 +91,7 @@ def test_syntax_error_pylint(config, workspace):
         assert diag["severity"] == lsp.DiagnosticSeverity.Error
 
 
-def test_lint_free_pylint(config, workspace):
+def test_lint_free_pylint(config, workspace) -> None:
     # Can't use temp_document because it might give us a file that doesn't
     # match pylint's naming requirements. We should be keeping this file clean
     # though, so it works for a test of an empty lint.
@@ -101,7 +101,7 @@ def test_lint_free_pylint(config, workspace):
     )
 
 
-def test_lint_caching(workspace):
+def test_lint_caching(workspace) -> None:
     # Pylint can only operate on files, not in-memory contents. We cache the
     # diagnostics after a run so we can continue displaying them until the file
     # is saved again.
@@ -129,7 +129,7 @@ def test_lint_caching(workspace):
         assert not pylint_lint.PylintLinter.lint(doc, False, flags)
 
 
-def test_per_file_caching(config, workspace):
+def test_per_file_caching(config, workspace) -> None:
     # Ensure that diagnostics are cached per-file.
     with temp_document(DOC, workspace) as doc:
         assert pylint_lint.pylsp_lint(config, workspace, doc, True)

--- a/test/plugins/test_references.py
+++ b/test/plugins/test_references.py
@@ -35,7 +35,7 @@ def tmp_workspace(temp_workspace_factory):
     )
 
 
-def test_references(tmp_workspace):
+def test_references(tmp_workspace) -> None:
     # Over 'Test1' in class Test1():
     position = {"line": 0, "character": 8}
     DOC1_URI = uris.from_fs_path(os.path.join(tmp_workspace.root_path, DOC1_NAME))
@@ -65,7 +65,7 @@ def test_references(tmp_workspace):
     assert doc2_usage_ref["range"]["end"] == {"line": 3, "character": 9}
 
 
-def test_references_builtin(tmp_workspace):
+def test_references_builtin(tmp_workspace) -> None:
     # Over 'UnicodeError':
     position = {"line": 4, "character": 7}
     doc2_uri = uris.from_fs_path(os.path.join(str(tmp_workspace.root_path), DOC2_NAME))

--- a/test/plugins/test_signature.py
+++ b/test/plugins/test_signature.py
@@ -42,7 +42,7 @@ main(
 """
 
 
-def test_no_signature(workspace):
+def test_no_signature(workspace) -> None:
     # Over blank line
     sig_position = {"line": 9, "character": 0}
     doc = Document(DOC_URI, workspace, DOC)
@@ -51,7 +51,7 @@ def test_no_signature(workspace):
     assert not sigs
 
 
-def test_signature(workspace):
+def test_signature(workspace) -> None:
     # Over '( ' in main(
     sig_position = {"line": 10, "character": 5}
     doc = Document(DOC_URI, workspace, DOC)
@@ -70,7 +70,7 @@ def test_signature(workspace):
     assert sig_info["activeParameter"] == 0
 
 
-def test_multi_line_signature(workspace):
+def test_multi_line_signature(workspace) -> None:
     # Over '( ' in main(
     sig_position = {"line": 17, "character": 5}
     doc = Document(DOC_URI, workspace, MULTI_LINE_DOC)
@@ -100,7 +100,7 @@ def test_multi_line_signature(workspace):
         (signature.GOOGLE, "    test (str): parameter docstring"),
     ],
 )
-def test_docstring_params(regex, doc):
+def test_docstring_params(regex, doc) -> None:
     m = regex.match(doc)
     assert m.group("param") == "test"
     assert m.group("doc") == "parameter docstring"

--- a/test/plugins/test_symbols.py
+++ b/test/plugins/test_symbols.py
@@ -73,13 +73,13 @@ def test_symbols(config, workspace):
     assert sym("main")["location"]["range"]["end"] == {"line": 12, "character": 0}
 
 
-def test_symbols_all_scopes(config, workspace):
+def test_symbols_all_scopes(config, workspace) -> None:
     doc = Document(DOC_URI, workspace, DOC)
     symbols = pylsp_document_symbols(config, doc)
     helper_check_symbols_all_scope(symbols)
 
 
-def test_symbols_non_existing_file(config, workspace, tmpdir):
+def test_symbols_non_existing_file(config, workspace, tmpdir) -> None:
     path = tmpdir.join("foo.py")
     # Check pre-condition: file must not exist
     assert not path.check(exists=1)
@@ -92,7 +92,7 @@ def test_symbols_non_existing_file(config, workspace, tmpdir):
 @pytest.mark.skipif(
     PY2 or not LINUX or not CI, reason="tested on linux and python 3 only"
 )
-def test_symbols_all_scopes_with_jedi_environment(workspace):
+def test_symbols_all_scopes_with_jedi_environment(workspace) -> None:
     doc = Document(DOC_URI, workspace, DOC)
 
     # Update config extra environment

--- a/test/plugins/test_yapf_format.py
+++ b/test/plugins/test_yapf_format.py
@@ -27,14 +27,14 @@ FOUR_SPACE_DOC = """def hello():
 """
 
 
-def test_format(workspace):
+def test_format(workspace) -> None:
     doc = Document(DOC_URI, workspace, DOC)
     res = pylsp_format_document(workspace, doc, None)
 
     assert apply_text_edits(doc, res) == "A = ['h', 'w', 'a']\n\nB = ['h', 'w']\n"
 
 
-def test_range_format(workspace):
+def test_range_format(workspace) -> None:
     doc = Document(DOC_URI, workspace, DOC)
 
     def_range = {
@@ -47,12 +47,12 @@ def test_range_format(workspace):
     assert apply_text_edits(doc, res) == "A = ['h', 'w', 'a']\n\nB = ['h',\n\n\n'w']\n"
 
 
-def test_no_change(workspace):
+def test_no_change(workspace) -> None:
     doc = Document(DOC_URI, workspace, GOOD_DOC)
     assert not pylsp_format_document(workspace, doc, options=None)
 
 
-def test_config_file(tmpdir, workspace):
+def test_config_file(tmpdir, workspace) -> None:
     # a config file in the same directory as the source file will be used
     conf = tmpdir.join(".style.yapf")
     conf.write("[style]\ncolumn_limit = 14")
@@ -69,7 +69,7 @@ def test_config_file(tmpdir, workspace):
 
 
 @pytest.mark.parametrize("newline", ["\r\n"])
-def test_line_endings(workspace, newline):
+def test_line_endings(workspace, newline) -> None:
     doc = Document(DOC_URI, workspace, f"import os;import sys{2 * newline}dict(a=1)")
     res = pylsp_format_document(workspace, doc, options=None)
 
@@ -79,28 +79,28 @@ def test_line_endings(workspace, newline):
     )
 
 
-def test_format_with_tab_size_option(workspace):
+def test_format_with_tab_size_option(workspace) -> None:
     doc = Document(DOC_URI, workspace, FOUR_SPACE_DOC)
     res = pylsp_format_document(workspace, doc, {"tabSize": "8"})
 
     assert apply_text_edits(doc, res) == FOUR_SPACE_DOC.replace("    ", "        ")
 
 
-def test_format_with_insert_spaces_option(workspace):
+def test_format_with_insert_spaces_option(workspace) -> None:
     doc = Document(DOC_URI, workspace, FOUR_SPACE_DOC)
     res = pylsp_format_document(workspace, doc, {"insertSpaces": False})
 
     assert apply_text_edits(doc, res) == FOUR_SPACE_DOC.replace("    ", "\t")
 
 
-def test_format_with_yapf_specific_option(workspace):
+def test_format_with_yapf_specific_option(workspace) -> None:
     doc = Document(DOC_URI, workspace, FOUR_SPACE_DOC)
     res = pylsp_format_document(workspace, doc, {"USE_TABS": True})
 
     assert apply_text_edits(doc, res) == FOUR_SPACE_DOC.replace("    ", "\t")
 
 
-def test_format_returns_text_edit_per_line(workspace):
+def test_format_returns_text_edit_per_line(workspace) -> None:
     single_space_indent = """def wow():
  log("x")
  log("hi")"""

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -20,7 +20,7 @@ INITIALIZATION_OPTIONS = {
 
 
 @pytest.mark.skipif(IS_WIN, reason="Flaky on Windows")
-def test_set_flake8_using_init_opts(client_server_pair):
+def test_set_flake8_using_init_opts(client_server_pair) -> None:
     client, server = client_server_pair
     send_initialize_request(client, INITIALIZATION_OPTIONS)
     for key, value in INITIALIZATION_OPTIONS["pylsp"]["plugins"].items():
@@ -30,7 +30,7 @@ def test_set_flake8_using_init_opts(client_server_pair):
 
 
 @pytest.mark.skipif(IS_WIN, reason="Flaky on Windows")
-def test_set_flake8_using_workspace_did_change_configuration(client_server_pair):
+def test_set_flake8_using_workspace_did_change_configuration(client_server_pair) -> None:
     client, server = client_server_pair
     send_initialize_request(client, None)
     assert (

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -30,7 +30,9 @@ def test_set_flake8_using_init_opts(client_server_pair) -> None:
 
 
 @pytest.mark.skipif(IS_WIN, reason="Flaky on Windows")
-def test_set_flake8_using_workspace_did_change_configuration(client_server_pair) -> None:
+def test_set_flake8_using_workspace_did_change_configuration(
+    client_server_pair,
+) -> None:
     client, server = client_server_pair
     send_initialize_request(client, None)
     assert (

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -6,23 +6,23 @@ from test.fixtures import DOC, DOC_URI
 from pylsp.workspace import Document
 
 
-def test_document_props(doc):
+def test_document_props(doc) -> None:
     assert doc.uri == DOC_URI
     assert doc.source == DOC
 
 
-def test_document_lines(doc):
+def test_document_lines(doc) -> None:
     assert len(doc.lines) == 4
     assert doc.lines[0] == "import sys\n"
 
 
-def test_document_source_unicode(workspace):
+def test_document_source_unicode(workspace) -> None:
     document_mem = Document(DOC_URI, workspace, "my source")
     document_disk = Document(DOC_URI, workspace)
     assert isinstance(document_mem.source, type(document_disk.source))
 
 
-def test_offset_at_position(doc):
+def test_offset_at_position(doc) -> None:
     assert doc.offset_at_position({"line": 0, "character": 8}) == 8
     assert doc.offset_at_position({"line": 1, "character": 5}) == 16
     assert doc.offset_at_position({"line": 2, "character": 0}) == 12
@@ -30,7 +30,7 @@ def test_offset_at_position(doc):
     assert doc.offset_at_position({"line": 4, "character": 0}) == 51
 
 
-def test_word_at_position(doc):
+def test_word_at_position(doc) -> None:
     """Return the position under the cursor (or last in line if past the end)"""
     # import sys
     assert doc.word_at_position({"line": 0, "character": 8}) == "sys"
@@ -44,7 +44,7 @@ def test_word_at_position(doc):
     assert doc.word_at_position({"line": 4, "character": 0}) == ""
 
 
-def test_document_empty_edit(workspace):
+def test_document_empty_edit(workspace) -> None:
     doc = Document("file:///uri", workspace, "")
     doc.apply_change(
         {
@@ -58,7 +58,7 @@ def test_document_empty_edit(workspace):
     assert doc.source == "f"
 
 
-def test_document_line_edit(workspace):
+def test_document_line_edit(workspace) -> None:
     doc = Document("file:///uri", workspace, "itshelloworld")
     doc.apply_change(
         {
@@ -72,7 +72,7 @@ def test_document_line_edit(workspace):
     assert doc.source == "itsgoodbyeworld"
 
 
-def test_document_multiline_edit(workspace):
+def test_document_multiline_edit(workspace) -> None:
     old = ["def hello(a, b):\n", "    print a\n", "    print b\n"]
     doc = Document("file:///uri", workspace, "".join(old))
     doc.apply_change(
@@ -87,7 +87,7 @@ def test_document_multiline_edit(workspace):
     assert doc.lines == ["def hello(a, b):\n", "    print a, b\n"]
 
 
-def test_document_end_of_file_edit(workspace):
+def test_document_end_of_file_edit(workspace) -> None:
     old = ["print 'a'\n", "print 'b'\n"]
     doc = Document("file:///uri", workspace, "".join(old))
     doc.apply_change(

--- a/test/test_language_server.py
+++ b/test/test_language_server.py
@@ -16,7 +16,7 @@ CALL_TIMEOUT_IN_SECONDS = 10
 
 
 @pytest.fixture
-def client_exited_server():
+def client_exited_server() -> None:
     """A fixture that sets up a client/server pair that support checking parent process aliveness
     and assert the server has already exited
     """
@@ -29,7 +29,7 @@ def client_exited_server():
 
 @flaky(max_runs=10, min_passes=1)
 @pytest.mark.skipif(sys.platform == "darwin", reason="Too flaky on Mac")
-def test_initialize(client_server_pair):
+def test_initialize(client_server_pair) -> None:
     client, _ = client_server_pair
     response = client._endpoint.request(
         "initialize",
@@ -44,7 +44,7 @@ def test_initialize(client_server_pair):
 )
 def test_exit_with_parent_process_died(
     client_exited_server,
-):
+) -> None:
     # language server should have already exited before responding
     lsp_server, mock_process = (
         client_exited_server.client,
@@ -69,7 +69,7 @@ def test_exit_with_parent_process_died(
 @pytest.mark.skipif(sys.platform.startswith("linux"), reason="Fails on linux")
 def test_not_exit_without_check_parent_process_flag(
     client_server_pair,
-):
+) -> None:
     client, _ = client_server_pair
     response = send_initialize_request(client)
     assert "capabilities" in response
@@ -77,7 +77,7 @@ def test_not_exit_without_check_parent_process_flag(
 
 @flaky(max_runs=10, min_passes=1)
 @pytest.mark.skipif(RUNNING_IN_CI, reason="This test is hanging on CI")
-def test_missing_message(client_server_pair):
+def test_missing_message(client_server_pair) -> None:
     client, _ = client_server_pair
     with pytest.raises(JsonRpcMethodNotFound):
         client._endpoint.request("unknown_method").result(

--- a/test/test_notebook_document.py
+++ b/test/test_notebook_document.py
@@ -15,7 +15,7 @@ from pylsp.lsp import NotebookCellKind
 from pylsp.workspace import Notebook
 
 
-def wait_for_condition(condition, timeout=CALL_TIMEOUT_IN_SECONDS):
+def wait_for_condition(condition, timeout=CALL_TIMEOUT_IN_SECONDS) -> None:
     """Wait for a condition to be true, or timeout."""
     start_time = time.time()
     while not condition():
@@ -25,7 +25,7 @@ def wait_for_condition(condition, timeout=CALL_TIMEOUT_IN_SECONDS):
 
 
 @pytest.mark.skipif(IS_WIN, reason="Flaky on Windows")
-def test_initialize(client_server_pair):
+def test_initialize(client_server_pair) -> None:
     client, server = client_server_pair
     response = send_initialize_request(client)
     assert server.workspace is not None
@@ -34,7 +34,7 @@ def test_initialize(client_server_pair):
 
 
 @pytest.mark.skipif(IS_WIN, reason="Flaky on Windows")
-def test_workspace_did_change_configuration(client_server_pair):
+def test_workspace_did_change_configuration(client_server_pair) -> None:
     """Test that we can update a workspace config w/o error when a notebook is open."""
     client, server = client_server_pair
     send_initialize_request(client)
@@ -83,7 +83,7 @@ def test_workspace_did_change_configuration(client_server_pair):
 @pytest.mark.skipif(IS_WIN, reason="Flaky on Windows")
 def test_notebook_document__did_open(
     client_server_pair,
-):
+) -> None:
     client, server = client_server_pair
     send_initialize_request(client)
 
@@ -185,7 +185,7 @@ def test_notebook_document__did_open(
 @pytest.mark.skipif(IS_WIN, reason="Flaky on Windows")
 def test_notebook_document__did_change(
     client_server_pair,
-):
+) -> None:
     client, server = client_server_pair
     send_initialize_request(client)
 
@@ -420,7 +420,7 @@ def test_notebook_document__did_change(
 @pytest.mark.skipif(IS_WIN, reason="Flaky on Windows")
 def test_notebook__did_close(
     client_server_pair,
-):
+) -> None:
     client, server = client_server_pair
     send_initialize_request(client)
 
@@ -455,7 +455,7 @@ def test_notebook__did_close(
 
 
 @pytest.mark.skipif(IS_WIN, reason="Flaky on Windows")
-def test_notebook_definition(client_server_pair):
+def test_notebook_definition(client_server_pair) -> None:
     client, server = client_server_pair
     send_initialize_request(client)
 
@@ -490,7 +490,7 @@ def test_notebook_definition(client_server_pair):
 
 
 @pytest.mark.skipif(IS_WIN, reason="Flaky on Windows")
-def test_notebook_completion(client_server_pair):
+def test_notebook_completion(client_server_pair) -> None:
     """
     Tests that completions work across cell boundaries for notebook document support
     """

--- a/test/test_text_edit.py
+++ b/test/test_text_edit.py
@@ -7,7 +7,7 @@ from pylsp.text_edit import OverLappingTextEditException, apply_text_edits
 DOC_URI = uris.from_fs_path(__file__)
 
 
-def test_apply_text_edits_insert(pylsp):
+def test_apply_text_edits_insert(pylsp) -> None:
     pylsp.workspace.put_document(DOC_URI, "012345678901234567890123456789")
     test_doc = pylsp.workspace.get_document(DOC_URI)
 
@@ -108,7 +108,7 @@ def test_apply_text_edits_insert(pylsp):
     )
 
 
-def test_apply_text_edits_replace(pylsp):
+def test_apply_text_edits_replace(pylsp) -> None:
     pylsp.workspace.put_document(DOC_URI, "012345678901234567890123456789")
     test_doc = pylsp.workspace.get_document(DOC_URI)
 
@@ -217,7 +217,7 @@ def test_apply_text_edits_replace(pylsp):
     )
 
 
-def test_apply_text_edits_overlap(pylsp):
+def test_apply_text_edits_overlap(pylsp) -> None:
     pylsp.workspace.put_document(DOC_URI, "012345678901234567890123456789")
     test_doc = pylsp.workspace.get_document(DOC_URI)
 
@@ -275,7 +275,7 @@ def test_apply_text_edits_overlap(pylsp):
     assert did_throw
 
 
-def test_apply_text_edits_multiline(pylsp):
+def test_apply_text_edits_multiline(pylsp) -> None:
     pylsp.workspace.put_document(DOC_URI, "0\n1\n2\n3\n4")
     test_doc = pylsp.workspace.get_document(DOC_URI)
 

--- a/test/test_uris.py
+++ b/test/test_uris.py
@@ -17,7 +17,7 @@ from pylsp import uris
         ("file:/foo/space%20%3Fbar#frag", "/foo/space ?bar"),
     ],
 )
-def test_to_fs_path(uri, path):
+def test_to_fs_path(uri, path) -> None:
     assert uris.to_fs_path(uri) == path
 
 
@@ -30,7 +30,7 @@ def test_to_fs_path(uri, path):
         ("file:///C:/far/space%20%3Fboo", "c:\\far\\space ?boo"),
     ],
 )
-def test_win_to_fs_path(uri, path):
+def test_win_to_fs_path(uri, path) -> None:
     assert uris.to_fs_path(uri) == path
 
 
@@ -42,7 +42,7 @@ def test_win_to_fs_path(uri, path):
         ("/foo/space ?bar", "file:///foo/space%20%3Fbar"),
     ],
 )
-def test_from_fs_path(path, uri):
+def test_from_fs_path(path, uri) -> None:
     assert uris.from_fs_path(path) == uri
 
 
@@ -54,7 +54,7 @@ def test_from_fs_path(path, uri):
         ("C:\\far\\space ?boo", "file:///c:/far/space%20%3Fboo"),
     ],
 )
-def test_win_from_fs_path(path, uri):
+def test_win_from_fs_path(path, uri) -> None:
     assert uris.from_fs_path(path) == uri
 
 
@@ -69,5 +69,5 @@ def test_win_from_fs_path(path, uri):
         ),
     ],
 )
-def test_uri_with(uri, kwargs, new_uri):
+def test_uri_with(uri, kwargs, new_uri) -> None:
     assert uris.uri_with(uri, **kwargs) == new_uri

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -19,7 +19,7 @@ from pylsp.python_lsp import PythonLSPServer, start_io_lang_server
 CALL_TIMEOUT_IN_SECONDS = 30
 
 
-def send_notebook_did_open(client, cells: List[str]):
+def send_notebook_did_open(client, cells: List[str]) -> None:
     """
     Sends a notebookDocument/didOpen notification with the given python cells.
 
@@ -72,7 +72,7 @@ def send_initialize_request(client, initialization_options: Dict[str, Any] = Non
     ).result(timeout=CALL_TIMEOUT_IN_SECONDS)
 
 
-def start(obj):
+def start(obj) -> None:
     obj.start()
 
 
@@ -85,7 +85,7 @@ class ClientServerPair:
         check_parent_process: if True, the server_process will check if the parent process is alive.
     """
 
-    def __init__(self, start_server_in_process=False, check_parent_process=False):
+    def __init__(self, start_server_in_process=False, check_parent_process=False) -> None:
         # Client to Server pipe
         csr, csw = os.pipe()
         # Server to client pipe
@@ -123,7 +123,7 @@ class ClientServerPair:
 
 
 @flaky(max_runs=6, min_passes=1)
-def test_debounce():
+def test_debounce() -> None:
     interval = 0.1
     obj = mock.Mock()
 
@@ -147,7 +147,7 @@ def test_debounce():
 
 
 @flaky(max_runs=6, min_passes=1)
-def test_debounce_keyed_by():
+def test_debounce_keyed_by() -> None:
     interval = 0.1
     obj = mock.Mock()
 
@@ -180,12 +180,12 @@ def test_debounce_keyed_by():
     assert len(obj.mock_calls) == 4
 
 
-def test_list_to_string():
+def test_list_to_string() -> None:
     assert _utils.list_to_string("string") == "string"
     assert _utils.list_to_string(["a", "r", "r", "a", "y"]) == "a,r,r,a,y"
 
 
-def test_find_parents(tmpdir):
+def test_find_parents(tmpdir) -> None:
     subsubdir = tmpdir.ensure_dir("subdir", "subsubdir")
     path = subsubdir.ensure("path.py")
     test_cfg = tmpdir.ensure("test.cfg")
@@ -195,14 +195,14 @@ def test_find_parents(tmpdir):
     ]
 
 
-def test_merge_dicts():
+def test_merge_dicts() -> None:
     assert _utils.merge_dicts(
         {"a": True, "b": {"x": 123, "y": {"hello": "world"}}},
         {"a": False, "b": {"y": [], "z": 987}},
     ) == {"a": False, "b": {"x": 123, "y": [], "z": 987}}
 
 
-def test_clip_column():
+def test_clip_column() -> None:
     assert _utils.clip_column(0, [], 0) == 0
     assert _utils.clip_column(2, ["123"], 0) == 2
     assert _utils.clip_column(3, ["123"], 0) == 3
@@ -215,7 +215,7 @@ def test_clip_column():
 
 
 @mock.patch("docstring_to_markdown.convert")
-def test_format_docstring_valid_rst_signature(mock_convert):
+def test_format_docstring_valid_rst_signature(mock_convert) -> None:
     """Test that a valid RST docstring includes the function signature."""
     docstring = """A function docstring.
 
@@ -244,7 +244,7 @@ def test_format_docstring_valid_rst_signature(mock_convert):
 
 
 @mock.patch("docstring_to_markdown.convert", side_effect=UnknownFormatError)
-def test_format_docstring_invalid_rst_signature(_):
+def test_format_docstring_invalid_rst_signature(_) -> None:
     """Test that an invalid RST docstring includes the function signature."""
     docstring = """A function docstring.
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -85,7 +85,9 @@ class ClientServerPair:
         check_parent_process: if True, the server_process will check if the parent process is alive.
     """
 
-    def __init__(self, start_server_in_process=False, check_parent_process=False) -> None:
+    def __init__(
+        self, start_server_in_process=False, check_parent_process=False
+    ) -> None:
         # Client to Server pipe
         csr, csw = os.pipe()
         # Server to client pipe

--- a/test/test_workspace.py
+++ b/test/test_workspace.py
@@ -14,32 +14,32 @@ def path_as_uri(path):
     return pathlib.Path(os.path.abspath(path)).as_uri()
 
 
-def test_local(pylsp):
+def test_local(pylsp) -> None:
     """Since the workspace points to the test directory"""
     assert pylsp.workspace.is_local()
 
 
-def test_put_document(pylsp):
+def test_put_document(pylsp) -> None:
     pylsp.workspace.put_document(DOC_URI, "content")
     assert DOC_URI in pylsp.workspace._docs
 
 
-def test_put_notebook_document(pylsp):
+def test_put_notebook_document(pylsp) -> None:
     pylsp.workspace.put_notebook_document(DOC_URI, "jupyter-notebook", [])
     assert DOC_URI in pylsp.workspace._docs
 
 
-def test_put_cell_document(pylsp):
+def test_put_cell_document(pylsp) -> None:
     pylsp.workspace.put_cell_document(DOC_URI, NOTEBOOK_URI, "python", "content")
     assert DOC_URI in pylsp.workspace._docs
 
 
-def test_get_document(pylsp):
+def test_get_document(pylsp) -> None:
     pylsp.workspace.put_document(DOC_URI, "TEXT")
     assert pylsp.workspace.get_document(DOC_URI).source == "TEXT"
 
 
-def test_get_missing_document(tmpdir, pylsp):
+def test_get_missing_document(tmpdir, pylsp) -> None:
     source = "TEXT"
     doc_path = tmpdir.join("test_document.py")
     doc_path.write(source)
@@ -47,7 +47,7 @@ def test_get_missing_document(tmpdir, pylsp):
     assert pylsp.workspace.get_document(doc_uri).source == "TEXT"
 
 
-def test_rm_document(pylsp):
+def test_rm_document(pylsp) -> None:
     pylsp.workspace.put_document(DOC_URI, "TEXT")
     assert pylsp.workspace.get_document(DOC_URI).source == "TEXT"
     pylsp.workspace.rm_document(DOC_URI)
@@ -57,7 +57,7 @@ def test_rm_document(pylsp):
 @pytest.mark.parametrize(
     "metafiles", [("setup.py",), ("pyproject.toml",), ("setup.py", "pyproject.toml")]
 )
-def test_non_root_project(pylsp, metafiles):
+def test_non_root_project(pylsp, metafiles) -> None:
     repo_root = os.path.join(pylsp.workspace.root_path, "repo-root")
     os.mkdir(repo_root)
     project_root = os.path.join(repo_root, "project-root")
@@ -73,7 +73,7 @@ def test_non_root_project(pylsp, metafiles):
     assert project_root in test_doc.sys_path()
 
 
-def test_root_project_with_no_setup_py(pylsp):
+def test_root_project_with_no_setup_py(pylsp) -> None:
     """Default to workspace root."""
     workspace_root = pylsp.workspace.root_path
     test_uri = uris.from_fs_path(os.path.join(workspace_root, "hello/test.py"))
@@ -82,7 +82,7 @@ def test_root_project_with_no_setup_py(pylsp):
     assert workspace_root in test_doc.sys_path()
 
 
-def test_multiple_workspaces_from_initialize(pylsp_w_workspace_folders):
+def test_multiple_workspaces_from_initialize(pylsp_w_workspace_folders) -> None:
     pylsp, workspace_folders = pylsp_w_workspace_folders
 
     assert len(pylsp.workspaces) == 2
@@ -113,7 +113,7 @@ def test_multiple_workspaces_from_initialize(pylsp_w_workspace_folders):
     assert msg2["uri"] in pylsp.workspaces[folders_uris[1]]._docs
 
 
-def test_multiple_workspaces(tmpdir, pylsp):
+def test_multiple_workspaces(tmpdir, pylsp) -> None:
     workspace1_dir = tmpdir.mkdir("workspace1")
     workspace2_dir = tmpdir.mkdir("workspace2")
     file1 = workspace1_dir.join("file1.py")
@@ -150,14 +150,14 @@ def test_multiple_workspaces(tmpdir, pylsp):
     assert workspace1_uri not in pylsp.workspaces
 
 
-def test_multiple_workspaces_wrong_removed_uri(pylsp, tmpdir):
+def test_multiple_workspaces_wrong_removed_uri(pylsp, tmpdir) -> None:
     workspace = {"uri": str(tmpdir.mkdir("Test123"))}
     event = {"added": [], "removed": [workspace]}
     pylsp.m_workspace__did_change_workspace_folders(event)
     assert workspace["uri"] not in pylsp.workspaces
 
 
-def test_root_workspace_changed(pylsp, tmpdir):
+def test_root_workspace_changed(pylsp, tmpdir) -> None:
     test_uri = str(tmpdir.mkdir("Test123"))
     pylsp.root_uri = test_uri
     pylsp.workspace._root_uri = test_uri
@@ -172,7 +172,7 @@ def test_root_workspace_changed(pylsp, tmpdir):
     assert workspace2["uri"] == pylsp.root_uri
 
 
-def test_root_workspace_not_changed(pylsp, tmpdir):
+def test_root_workspace_not_changed(pylsp, tmpdir) -> None:
     # removed uri != root_uri
     test_uri_1 = str(tmpdir.mkdir("Test12"))
     pylsp.root_uri = test_uri_1
@@ -206,7 +206,7 @@ def test_root_workspace_not_changed(pylsp, tmpdir):
     assert new_root_uri == pylsp.root_uri
 
 
-def test_root_workspace_removed(tmpdir, pylsp):
+def test_root_workspace_removed(tmpdir, pylsp) -> None:
     workspace1_dir = tmpdir.mkdir("workspace1")
     workspace2_dir = tmpdir.mkdir("workspace2")
     root_uri = pylsp.root_uri
@@ -230,7 +230,7 @@ def test_root_workspace_removed(tmpdir, pylsp):
 
 
 @pytest.mark.skipif(os.name == "nt", reason="Fails on Windows")
-def test_workspace_loads_pycodestyle_config(pylsp, tmpdir):
+def test_workspace_loads_pycodestyle_config(pylsp, tmpdir) -> None:
     workspace1_dir = tmpdir.mkdir("Test123")
     pylsp.root_uri = str(workspace1_dir)
     pylsp.workspace._root_uri = str(workspace1_dir)
@@ -268,7 +268,7 @@ def test_workspace_loads_pycodestyle_config(pylsp, tmpdir):
     assert seetings["plugins"]["pycodestyle"]["maxLineLength"] == 20
 
 
-def test_settings_of_added_workspace(pylsp, tmpdir):
+def test_settings_of_added_workspace(pylsp, tmpdir) -> None:
     test_uri = str(tmpdir.mkdir("Test123"))
     pylsp.root_uri = test_uri
     pylsp.workspace._root_uri = test_uri
@@ -290,7 +290,7 @@ def test_settings_of_added_workspace(pylsp, tmpdir):
     assert workspace1_jedi_settings == server_settings["pylsp"]["plugins"]["jedi"]
 
 
-def test_no_progress_without_capability(workspace, consumer):
+def test_no_progress_without_capability(workspace, consumer) -> None:
     workspace._config.capabilities["window"] = {"workDoneProgress": False}
 
     with workspace.report_progress("some_title"):
@@ -299,7 +299,7 @@ def test_no_progress_without_capability(workspace, consumer):
     assert len(consumer.call_args_list) == 0
 
 
-def test_progress_simple(workspace, consumer):
+def test_progress_simple(workspace, consumer) -> None:
     workspace._config.capabilities["window"] = {"workDoneProgress": True}
 
     with workspace.report_progress("some_title"):
@@ -332,7 +332,7 @@ def test_progress_simple(workspace, consumer):
 @pytest.mark.parametrize("exc", [Exception("something"), TimeoutError()])
 def test_progress_initialization_fails_but_is_skipped(
     workspace, consumer, endpoint, exc
-):
+) -> None:
     def failing_token_initialization(self, *_args, **_kwargs):
         raise exc
 
@@ -355,7 +355,7 @@ def test_progress_initialization_fails_but_is_skipped(
     ]
 
 
-def test_progress_with_percent(workspace, consumer):
+def test_progress_with_percent(workspace, consumer) -> None:
     workspace._config.capabilities["window"] = {"workDoneProgress": True}
 
     with workspace.report_progress(
@@ -395,7 +395,7 @@ def test_progress_with_percent(workspace, consumer):
     ]
 
 
-def test_progress_with_exception(workspace, consumer):
+def test_progress_with_exception(workspace, consumer) -> None:
     workspace._config.capabilities["window"] = {"workDoneProgress": True}
 
     class DummyError(Exception):


### PR DESCRIPTION
🚀 **Hi there!**

I'm Toni García, a colleague of @bagel897. Together, we're committed to improving code quality through automatically generated codemods. Our mission is to help maintain high standards by automating issue detection and resolution. 🔍✨

🎉 We're excited to start collaborating with your team! In our upcoming PRs, you can expect to see:
- 📈 Improvements in code quality.
- 🤖 Automation of common issues.
- 🛠️ Resolutions for existing problems.

These changes aim to be low-effort for the maintainers but highly effective in keeping the codebase clean and efficient.

🔧 For this first PR, we've focused on enhancing code clarity by adding explicit return types for Python methods that do not return anything. This small change helps improve readability and maintainability of the code. 💡

# 📬 FAQ
If you encounter any issues with the PR or want to discuss anything further, feel free to email me at [toni@codegen.com](mailto:toni@codegen.com). I'm always here to help and happy to talk to a human! 🙋‍♂️

# <img src="https://www.codegen.sh/favicon.ico" width="22" height="22">  Codegen • What is Codegen?
<h6>
    <p>Codegen unleashes the power of ⚡ GPT-4 code mods ⚡, fully integrated into your development workflow.</p>
    <p>
        <a href="https://www.codegen.com">Learn more</a>
    </p>
</h6>
</details>

Looking forward to your feedback and collaboration!

Cheers, Toni and Ellen