### PR TITLE
Use `%r` to have a better log

### DIFF
--- a/pylsp/_utils.py
+++ b/pylsp/_utils.py
@@ -88,7 +88,7 @@ def find_parents(root, path, names):
         return []
 
     if not os.path.commonprefix((root, path)):
-        log.warning("Path %s not in %s", path, root)
+        log.warning("Path %r not in %r", path, root)
         return []
 
     # Split the relative by directory, generate all the parent directories, then check each of them.


### PR DESCRIPTION
When writing a client, I got the error:
```
2024-07-24 11:35:19,459 IDT - WARNING - pylsp._utils - Path  not in /home/miki/work/autokitteh/src/playground/lsp/nlp
```

The path was empty, changed the log to use `%r` so empty string will be printed as `''`.