### PR TITLE
Update versions of Github actions used on CI

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -22,13 +22,13 @@ jobs:
       OS: 'linux'
     timeout-minutes: 2
     steps:
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: static-pip-${{ hashFiles('pyproject.toml') }}
           restore-keys: static-pip-
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           # TODO: check with Python 3, but need to fix the
           # errors first

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -27,13 +27,13 @@ jobs:
         PYTHON_VERSION: ['3.10', '3.9', '3.8']
     timeout-minutes: 10
     steps:
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-${{ matrix.PYTHON_VERSION }}-pip-${{ hashFiles('pyproject.toml') }}
           restore-keys: ${{ runner.os }}-${{ matrix.PYTHON_VERSION }}-pip-
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.PYTHON_VERSION }}
           architecture: 'x64'

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -27,13 +27,13 @@ jobs:
         PYTHON_VERSION: ['3.10', '3.9', '3.8']
     timeout-minutes: 10
     steps:
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         with:
           path: ~/Library/Caches/pip
           key: ${{ runner.os }}-${{ matrix.PYTHON_VERSION }}-pip-${{ hashFiles('pyproject.toml') }}
           restore-keys: ${{ runner.os }}-${{ matrix.PYTHON_VERSION }}-pip-
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.PYTHON_VERSION }}
           architecture: 'x64'

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -27,13 +27,13 @@ jobs:
         PYTHON_VERSION: ['3.10', '3.9', '3.8']
     timeout-minutes: 10
     steps:
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         with:
           path: ~\AppData\Local\pip\Cache
           key: ${{ runner.os }}-${{ matrix.PYTHON_VERSION }}-pip-${{ hashFiles('pyproject.toml') }}
           restore-keys: ${{ runner.os }}-${{ matrix.PYTHON_VERSION }}-pip-
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.PYTHON_VERSION }}
           architecture: 'x64'


### PR DESCRIPTION
It seems some actions are failing from time to time because they are too old.