### PR TITLE
Allow `jedi_hover` and `jedi_signature_help` plugins to hide docstrings.

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -37,8 +37,10 @@ This server can be configured using the `workspace/didChangeConfiguration` metho
 | `pylsp.plugins.jedi_definition.follow_builtin_imports` | `boolean` | If follow_imports is True will decide if it follow builtin imports. | `true` |
 | `pylsp.plugins.jedi_definition.follow_builtin_definitions` | `boolean` | Follow builtin and extension definitions to stubs. | `true` |
 | `pylsp.plugins.jedi_hover.enabled` | `boolean` | Enable or disable the plugin. | `true` |
+| `pylsp.plugins.jedi_hover.include_docstring` | `boolean` | Include signature docstring in the output. | `true` |
 | `pylsp.plugins.jedi_references.enabled` | `boolean` | Enable or disable the plugin. | `true` |
 | `pylsp.plugins.jedi_signature_help.enabled` | `boolean` | Enable or disable the plugin. | `true` |
+| `pylsp.plugins.jedi_signature_help.include_docstring` | `boolean` | Include signature docstring in the output. | `true` |
 | `pylsp.plugins.jedi_symbols.enabled` | `boolean` | Enable or disable the plugin. | `true` |
 | `pylsp.plugins.jedi_symbols.all_scopes` | `boolean` | If True lists the names of all scopes instead of only the module namespace. | `true` |
 | `pylsp.plugins.jedi_symbols.include_import_symbols` | `boolean` | If True includes symbols imported from other libraries. | `true` |

--- a/pylsp/_utils.py
+++ b/pylsp/_utils.py
@@ -315,17 +315,24 @@ def format_docstring(
         contents = ""
 
     if markup_kind == "markdown":
-        try:
-            value = docstring_to_markdown.convert(contents)
-        except docstring_to_markdown.UnknownFormatError:
-            # try to escape the Markdown syntax instead:
-            value = escape_markdown(contents)
+        wrapped_signatures = convert_signatures_to_markdown(
+            signatures if signatures is not None else [], config=signature_config or {}
+        )
 
-        if signatures:
-            wrapped_signatures = convert_signatures_to_markdown(
-                signatures, config=signature_config or {}
-            )
-            value = wrapped_signatures + "\n\n" + value
+        if contents != "":
+            try:
+                value = docstring_to_markdown.convert(contents)
+            except docstring_to_markdown.UnknownFormatError:
+                # try to escape the Markdown syntax instead:
+                value = escape_markdown(contents)
+
+            if signatures:
+                value = wrapped_signatures + "\n\n" + value
+        else:
+            value = contents
+
+            if signatures:
+                value = wrapped_signatures
 
         return {"kind": "markdown", "value": value}
     value = contents

--- a/pylsp/config/schema.json
+++ b/pylsp/config/schema.json
@@ -245,6 +245,11 @@
       "default": true,
       "description": "Enable or disable the plugin."
     },
+    "pylsp.plugins.jedi_hover.include_docstring": {
+      "type": "boolean",
+      "default": true,
+      "description": "Include signature docstring in the output."
+    },
     "pylsp.plugins.jedi_references.enabled": {
       "type": "boolean",
       "default": true,
@@ -254,6 +259,11 @@
       "type": "boolean",
       "default": true,
       "description": "Enable or disable the plugin."
+    },
+    "pylsp.plugins.jedi_signature_help.include_docstring": {
+      "type": "boolean",
+      "default": true,
+      "description": "Include signature docstring in the output."
     },
     "pylsp.plugins.jedi_symbols.enabled": {
       "type": "boolean",

--- a/pylsp/plugins/hover.py
+++ b/pylsp/plugins/hover.py
@@ -11,6 +11,7 @@ log = logging.getLogger(__name__)
 @hookimpl
 def pylsp_hover(config, document, position):
     signature_config = config.settings().get("signature", {})
+    settings = config.plugin_settings("jedi_hover", document_path=document.path)
     code_position = _utils.position_to_jedi_linecolumn(document, position)
     definitions = document.jedi_script(use_document_path=True).infer(**code_position)
     word = document.word_at_position(position)
@@ -41,10 +42,19 @@ def pylsp_hover(config, document, position):
         "",
     )
 
+    include_docstring = settings.get("include_docstring", True)
+
+    # raw docstring returns only doc, without signature
+    docstring = definition.docstring(raw=True)
+    if include_docstring is False:
+        if signature:
+            docstring = ""
+        else:
+            docstring = docstring.strip().split("\n")[0].strip()
+
     return {
         "contents": _utils.format_docstring(
-            # raw docstring returns only doc, without signature
-            definition.docstring(raw=True),
+            docstring,
             preferred_markup_kind,
             signatures=[signature] if signature else None,
             signature_config=signature_config,

--- a/pylsp/plugins/signature.py
+++ b/pylsp/plugins/signature.py
@@ -17,6 +17,9 @@ DOC_REGEX = [SPHINX, EPYDOC, GOOGLE]
 
 @hookimpl
 def pylsp_signature_help(config, document, position):
+    settings = config.plugin_settings(
+        "jedi_signature_help", document_path=document.path
+    )
     code_position = _utils.position_to_jedi_linecolumn(document, position)
     signatures = document.jedi_script().get_signatures(**code_position)
 
@@ -41,10 +44,15 @@ def pylsp_signature_help(config, document, position):
     # Docstring contains one or more lines of signature, followed by empty line, followed by docstring
     function_sig_lines = (docstring.split("\n\n") or [""])[0].splitlines()
     function_sig = " ".join([line.strip() for line in function_sig_lines])
+
+    signature_docstring = s.docstring(raw=True)
+    if settings.get("include_docstring", True) is False:
+        signature_docstring = ""
+
     sig = {
         "label": function_sig,
         "documentation": _utils.format_docstring(
-            s.docstring(raw=True), markup_kind=preferred_markup_kind
+            signature_docstring, markup_kind=preferred_markup_kind
         ),
     }
 

--- a/test/plugins/test_hover.py
+++ b/test/plugins/test_hover.py
@@ -3,6 +3,8 @@
 
 import os
 
+import pytest
+
 from pylsp import uris
 from pylsp.plugins.hover import pylsp_hover
 from pylsp.workspace import Document
@@ -21,6 +23,17 @@ import numpy as np
 np.sin
 
 """
+
+
+@pytest.fixture
+def workspace_with_hover_docstring_disabled(workspace) -> None:
+    workspace._config._settings["plugins"] = {
+        "jedi_hover": {
+            "include_docstring": False,
+        },
+    }
+
+    yield workspace
 
 
 def test_numpy_hover(workspace) -> None:
@@ -143,3 +156,17 @@ foo"""
     contents = pylsp_hover(doc._config, doc, cursor_pos)["contents"]
 
     assert "A docstring for foo." in contents["value"]
+
+
+def test_hover_without_docstring(workspace_with_hover_docstring_disabled) -> None:
+    # Over 'main' in def main():
+    hov_position = {"line": 2, "character": 6}
+
+    doc = Document(DOC_URI, workspace_with_hover_docstring_disabled, DOC)
+
+    contents = {
+        "kind": "markdown",
+        "value": "```python\nmain(a: float, b: float)\n```\n",
+    }
+
+    assert {"contents": contents} == pylsp_hover(doc._config, doc, hov_position)


### PR DESCRIPTION
Both the plugins include a signature's docstring by the default in the content they generate. Which is cool, as long as the docstring's author doesn't moonlight as a novelist. Otherwise, the content rendered in the popup will cover the entire screen. It's annoying to say the least.

This changeset allows a user to hide the docstrings by adding config flags. They default to `true` so people aren't surprised by the change. I've been running this version in ST4 with no issues for a while, so I'm submitting it as a PR.