### PR TITLE
Replace ujson with orjson

### DIFF
--- a/pylsp/__main__.py
+++ b/pylsp/__main__.py
@@ -2,15 +2,11 @@
 # Copyright 2021- Python Language Server Contributors.
 
 import argparse
+import json
 import logging
 import logging.config
 import sys
 import time
-
-try:
-    import ujson as json
-except Exception:
-    import json
 
 from ._version import __version__
 from .python_lsp import (

--- a/pylsp/plugins/pylint_lint.py
+++ b/pylsp/plugins/pylint_lint.py
@@ -15,8 +15,8 @@ from subprocess import PIPE, Popen
 from pylsp import hookimpl, lsp
 
 try:
-    import ujson as json
-except Exception:
+    import orjson as json
+except ImportError:
     import json
 
 log = logging.getLogger(__name__)

--- a/pylsp/python_lsp.py
+++ b/pylsp/python_lsp.py
@@ -10,8 +10,8 @@ from functools import partial
 from typing import Any, Dict, List
 
 try:
-    import ujson as json
-except Exception:
+    import orjson as json
+except ImportError:
     import json
 
 from pylsp_jsonrpc.dispatchers import MethodDispatcher

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "jedi>=0.17.2,<0.20.0",
     "pluggy>=1.0.0",
     "python-lsp-jsonrpc>=1.1.0,<2.0.0",
-    "ujson>=3.0.0",
+    "orjson>=3.10.0",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "importlib_metadata>=4.8.3;python_version<\"3.10\"",
     "jedi>=0.17.2,<0.20.0",
     "pluggy>=1.0.0",
-    "python-lsp-jsonrpc @ git+ssh://git@github.com/valrus/python-lsp-jsonrpc#replace-ujson-with-orjson",
+    "python-lsp-jsonrpc @ git+https://github.com/valrus/python-lsp-jsonrpc#egg=replace-ujson-with-orjson",
     "orjson>=3.10.0",
 ]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "importlib_metadata>=4.8.3;python_version<\"3.10\"",
     "jedi>=0.17.2,<0.20.0",
     "pluggy>=1.0.0",
-    "python-lsp-jsonrpc>=1.1.0,<2.0.0",
+    "python-lsp-jsonrpc @ git+ssh://git@github.com/valrus/python-lsp-jsonrpc#replace-ujson-with-orjson",
     "orjson>=3.10.0",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
This PR is a small update to @rumpelsepp's here: https://github.com/python-lsp/python-lsp-server/pull/579
It just points the `python-lsp-jsonrpc` dependency at the branch I have PR'd at https://github.com/python-lsp/python-lsp-jsonrpc/pull/29, to demonstrate the tests pass.