### PR TITLE
Correctly handle null value for `ropeFolder` config

### DIFF
--- a/pylsp/workspace.py
+++ b/pylsp/workspace.py
@@ -77,7 +77,7 @@ class Workspace:
         # TODO: we could keep track of dirty files and validate only those
         if self.__rope is None or self.__rope_config != rope_config:
             rope_folder = rope_config.get("ropeFolder")
-            if rope_folder:
+            if "ropeFolder" in rope_config:
                 self.__rope = Project(self._root_path, ropefolder=rope_folder)
             else:
                 self.__rope = Project(self._root_path)


### PR DESCRIPTION
In Zed we've tweaked defaults of pylsp for rope as we do not want it to create any files in users projects by default; we've happily passed null as an initialization option for ropeFolder only to find out that it is not handled correctly by plugin shim on pylsp side.

The faulty logic lies in the fact that dict.get returns None by default when a value is not present in dictionary, whereas it is also a valid user-provided value. Thus, when we check whether there's an user-supplied ropeFolder, we end up falling back to ropes default when said user provided value is null.

This PR fixes this issue by explicitly checking whether there's an user-provided `ropeFolder` and using that (regardless of it's value) if it's set.