### PR TITLE
Make path separator escape configurable (#373)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -25,6 +25,7 @@ This server can be configured using the `workspace/didChangeConfiguration` metho
 | `pylsp.plugins.jedi.env_vars` | `object` | Define environment variables for jedi.Script and Jedi.names. | `null` |
 | `pylsp.plugins.jedi.environment` | `string` | Define environment for jedi.Script and Jedi.names. | `null` |
 | `pylsp.plugins.jedi_completion.enabled` | `boolean` | Enable or disable the plugin. | `true` |
+| `pylsp.plugins.jedi_completion.escape_path_sep` | `boolean` | Force path separators to be escaped in file path completions. | `true` |
 | `pylsp.plugins.jedi_completion.include_params` | `boolean` | Auto-completes methods and classes with tabstops for each parameter. | `true` |
 | `pylsp.plugins.jedi_completion.include_class_objects` | `boolean` | Adds class objects as a separate completion item. | `false` |
 | `pylsp.plugins.jedi_completion.include_function_objects` | `boolean` | Adds function objects as a separate completion item. | `false` |

--- a/pylsp/plugins/jedi_completion.py
+++ b/pylsp/plugins/jedi_completion.py
@@ -80,6 +80,8 @@ def pylsp_completions(config, document, position):
         and use_snippets(document, position)
     )
 
+    escape_path_sep = settings.get("escape_path_sep", snippet_support)
+
     ready_completions = [
         _format_completion(
             c,
@@ -87,7 +89,7 @@ def pylsp_completions(config, document, position):
             include_params=include_params if c.type in ["class", "function"] else False,
             resolve=resolve_eagerly,
             resolve_label_or_snippet=(i < max_to_resolve),
-            snippet_support=snippet_support,
+            escape_path_sep=escape_path_sep,
         )
         for i, c in enumerate(completions)
     ]
@@ -102,7 +104,7 @@ def pylsp_completions(config, document, position):
                     include_params=False,
                     resolve=resolve_eagerly,
                     resolve_label_or_snippet=(i < max_to_resolve),
-                    snippet_support=snippet_support,
+                    escape_path_sep=escape_path_sep,
                 )
                 completion_dict["kind"] = lsp.CompletionItemKind.TypeParameter
                 completion_dict["label"] += " object"
@@ -117,7 +119,7 @@ def pylsp_completions(config, document, position):
                     include_params=False,
                     resolve=resolve_eagerly,
                     resolve_label_or_snippet=(i < max_to_resolve),
-                    snippet_support=snippet_support,
+                    escape_path_sep=escape_path_sep,
                 )
                 completion_dict["kind"] = lsp.CompletionItemKind.TypeParameter
                 completion_dict["label"] += " object"
@@ -227,7 +229,7 @@ def _format_completion(
     include_params=True,
     resolve=False,
     resolve_label_or_snippet=False,
-    snippet_support=False,
+    escape_path_sep=False,
 ):
     completion = {
         "label": _label(d, resolve_label_or_snippet),
@@ -253,7 +255,7 @@ def _format_completion(
 
         # Escape to prevent conflicts with the code snippets grammer
         # See also https://github.com/python-lsp/python-lsp-server/issues/373
-        if snippet_support:
+        if escape_path_sep:
             path = path.replace("\\", "\\\\")
             path = path.replace("/", "\\/")
 


### PR DESCRIPTION
This adds an opt-out for the forced path separator escaping added for #373. This fixes an issue where paths are always escaped, making this feature unusable without constant backtracking to remove escapes (see https://github.com/sublimelsp/LSP-pylsp/issues/180). 

I don't know how valid the default listed in CONFIGURATION.md is (the default value is whether or not snippets are supported, which always seems to be `true`) but I can't figure out how better to phrase it.

### Demo

[demo-fix.webm](https://github.com/user-attachments/assets/82e47b1d-ff70-414a-a54e-0b09f08c5393)


### References
* #373
* https://github.com/sublimelsp/LSP-pylsp/issues/180