### PR TITLE
Do not call `str.splitlines()` twice in the same function.

### DIFF
--- a/pylsp/workspace.py
+++ b/pylsp/workspace.py
@@ -460,7 +460,8 @@ class Document:
         end_col = change_range["end"]["character"]
 
         # Check for an edit occuring at the very end of the file
-        if start_line == len(self.lines):
+        lines = self.lines
+        if start_line == len(lines):
             self._source = self.source + text
             return
 
@@ -469,7 +470,7 @@ class Document:
         # Iterate over the existing document until we hit the edit range,
         # at which point we write the new text, then loop until we hit
         # the end of the range and continue writing.
-        for i, line in enumerate(self.lines):
+        for i, line in enumerate(lines):
             if i < start_line:
                 new.write(line)
                 continue
@@ -493,10 +494,11 @@ class Document:
 
     def word_at_position(self, position):
         """Get the word under the cursor returning the start and end positions."""
-        if position["line"] >= len(self.lines):
+        lines = self.lines
+        if position["line"] >= len(lines):
             return ""
 
-        line = self.lines[position["line"]]
+        line = lines[position["line"]]
         i = position["character"]
         # Split word in two
         start = line[:i]


### PR DESCRIPTION
The better solution might be to have a proper text editing framework, but since the code itself in workspace.py is very simple I'm proposing just this simple solution.