### PR TITLE
Add basic Goto Implementation Request support

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -72,6 +72,7 @@ This server can be configured using the `workspace/didChangeConfiguration` metho
 | `pylsp.plugins.rope_autoimport.memory` | `boolean` | Make the autoimport database memory only. Drastically increases startup time. | `false` |
 | `pylsp.plugins.rope_completion.enabled` | `boolean` | Enable or disable the plugin. | `false` |
 | `pylsp.plugins.rope_completion.eager` | `boolean` | Resolve documentation and detail eagerly. | `false` |
+| `pylsp.plugins.rope_implementation.enabled` | `boolean` | Enable or disable the plugin. | `true` |
 | `pylsp.plugins.yapf.enabled` | `boolean` | Enable or disable the plugin. | `true` |
 | `pylsp.rope.extensionModules` | `string` | Builtin and c-extension modules that are allowed to be imported and inspected by rope. | `null` |
 | `pylsp.rope.ropeFolder` | `array` of unique `string` items | The name of the folder in which rope stores project configurations and data.  Pass `null` for not using such a folder at all. | `null` |

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ pip install python-lsp-server
 This will expose the command `pylsp` on your PATH. Confirm that installation succeeded by running `pylsp --help`.
 
 If the respective dependencies are found, the following optional providers will be enabled:
-- [Rope](https://github.com/python-rope/rope) for Completions and renaming
+- [Rope](https://github.com/python-rope/rope) for Completions, Goto Implementation, and renaming
 - [Pyflakes](https://github.com/PyCQA/pyflakes) linter to detect various errors
 - [McCabe](https://github.com/PyCQA/mccabe) linter for complexity checking
 - [pycodestyle](https://github.com/PyCQA/pycodestyle) linter for style checking
@@ -151,7 +151,7 @@ pip install 'python-lsp-server[websockets]'
 * Code Linting
 * Code actions
 * Signature Help
-* Go to definition
+* Go to definition or implementation
 * Hover
 * Find References
 * Document Symbols

--- a/pylsp/config/schema.json
+++ b/pylsp/config/schema.json
@@ -487,6 +487,11 @@
       "default": false,
       "description": "Resolve documentation and detail eagerly."
     },
+    "pylsp.plugins.rope_implementation.enabled": {
+      "type": "boolean",
+      "default": true,
+      "description": "Enable or disable the plugin."
+    },
     "pylsp.plugins.yapf.enabled": {
       "type": "boolean",
       "default": true,

--- a/pylsp/hookspecs.py
+++ b/pylsp/hookspecs.py
@@ -94,6 +94,11 @@ def pylsp_hover(config, workspace, document, position) -> None:
 
 
 @hookspec
+def pylsp_implementations(config, workspace, document, position) -> None:
+    pass
+
+
+@hookspec
 def pylsp_initialize(config, workspace) -> None:
     pass
 

--- a/pylsp/plugins/rope_implementation.py
+++ b/pylsp/plugins/rope_implementation.py
@@ -1,0 +1,43 @@
+# Copyright 2017-2020 Palantir Technologies, Inc.
+# Copyright 2021- Python Language Server Contributors.
+import logging
+import os
+
+from rope.contrib.findit import find_implementations
+
+from pylsp import hookimpl, uris
+
+log = logging.getLogger(__name__)
+
+
+@hookimpl
+def pylsp_settings():
+    # Default to enabled (no reason not to)
+    return {"plugins": {"rope_implementation": {"enabled": True}}}
+
+
+@hookimpl
+def pylsp_implementations(config, workspace, document, position):
+    offset = document.offset_at_position(position)
+    rope_config = config.settings(document_path=document.path).get("rope", {})
+    rope_project = workspace._rope_project_builder(rope_config)
+    rope_resource = document._rope_resource(rope_config)
+
+    impls = find_implementations(rope_project, rope_resource, offset)
+
+    return [
+        {
+            "uri": uris.uri_with(
+                document.uri,
+                path=os.path.join(workspace.root_path, impl.resource.path),
+            ),
+            "range": {
+                # TODO: `impl.region` seems to be from the start of the file
+                # and offsets from the start of the line difficult to obtain,
+                # so we just return the whole line for now:
+                "start": {"line": impl.lineno - 1, "character": 0},
+                "end": {"line": impl.lineno - 1, "character": 999},
+            },
+        }
+        for impl in impls
+    ]

--- a/pylsp/plugins/rope_implementation.py
+++ b/pylsp/plugins/rope_implementation.py
@@ -2,8 +2,11 @@
 # Copyright 2021- Python Language Server Contributors.
 import logging
 import os
+from typing import Any
 
-from rope.contrib.findit import find_implementations
+from rope.base.project import Project
+from rope.base.resources import Resource
+from rope.contrib.findit import Location, find_implementations
 
 from pylsp import hookimpl, uris
 
@@ -31,13 +34,37 @@ def pylsp_implementations(config, workspace, document, position):
                 document.uri,
                 path=os.path.join(workspace.root_path, impl.resource.path),
             ),
-            "range": {
-                # TODO: `impl.region` seems to be from the start of the file
-                # and offsets from the start of the line difficult to obtain,
-                # so we just return the whole line for now:
-                "start": {"line": impl.lineno - 1, "character": 0},
-                "end": {"line": impl.lineno - 1, "character": 999},
-            },
+            "range": _rope_location_to_range(impl, rope_project),
         }
         for impl in impls
     ]
+
+
+def _rope_location_to_range(
+    location: Location, rope_project: Project
+) -> dict[str, Any]:
+    # NOTE: This assumes the result is confined to a single line, which should
+    # always be the case here because Python doesn't allow splitting up
+    # identifiers across more than one line.
+    start_column, end_column = _rope_region_to_columns(
+        location.region, location.lineno, location.resource, rope_project
+    )
+    return {
+        "start": {"line": location.lineno - 1, "character": start_column},
+        "end": {"line": location.lineno - 1, "character": end_column},
+    }
+
+
+def _rope_region_to_columns(
+    offsets: tuple[int, int], line: int, rope_resource: Resource, rope_project: Project
+) -> tuple[int, int]:
+    """
+    Convert pair of offsets from start of file to columns within line.
+
+    Assumes both offsets reside within the same line and will return nonsense
+    for the end offset if this isn't the case.
+    """
+    line_start_offset = rope_project.get_pymodule(rope_resource).lines.get_line_start(
+        line
+    )
+    return offsets[0] - line_start_offset, offsets[1] - line_start_offset

--- a/pylsp/plugins/rope_implementation.py
+++ b/pylsp/plugins/rope_implementation.py
@@ -2,7 +2,7 @@
 # Copyright 2021- Python Language Server Contributors.
 import logging
 import os
-from typing import Any
+from typing import Any, Dict, Tuple
 
 from rope.base.project import Project
 from rope.base.resources import Resource
@@ -42,7 +42,7 @@ def pylsp_implementations(config, workspace, document, position):
 
 def _rope_location_to_range(
     location: Location, rope_project: Project
-) -> dict[str, Any]:
+) -> Dict[str, Any]:
     # NOTE: This assumes the result is confined to a single line, which should
     # always be the case here because Python doesn't allow splitting up
     # identifiers across more than one line.
@@ -56,8 +56,8 @@ def _rope_location_to_range(
 
 
 def _rope_region_to_columns(
-    offsets: tuple[int, int], line: int, rope_resource: Resource, rope_project: Project
-) -> tuple[int, int]:
+    offsets: Tuple[int, int], line: int, rope_resource: Resource, rope_project: Project
+) -> Tuple[int, int]:
     """
     Convert pair of offsets from start of file to columns within line.
 

--- a/pylsp/plugins/rope_implementation.py
+++ b/pylsp/plugins/rope_implementation.py
@@ -26,7 +26,11 @@ def pylsp_implementations(config, workspace, document, position):
     rope_project = workspace._rope_project_builder(rope_config)
     rope_resource = document._rope_resource(rope_config)
 
-    impls = find_implementations(rope_project, rope_resource, offset)
+    try:
+        impls = find_implementations(rope_project, rope_resource, offset)
+    except Exception as e:
+         log.debug("Failed to run Rope implementations finder: %s", e)
+         return []
 
     return [
         {

--- a/pylsp/python_lsp.py
+++ b/pylsp/python_lsp.py
@@ -280,6 +280,7 @@ class PythonLSPServer(MethodDispatcher):
                 "commands": flatten(self._hook("pylsp_commands"))
             },
             "hoverProvider": True,
+            "implementationProvider": True,  # only when Rope is installed
             "referencesProvider": True,
             "renameProvider": True,
             "foldingRangeProvider": True,
@@ -435,6 +436,9 @@ class PythonLSPServer(MethodDispatcher):
 
     def hover(self, doc_uri, position):
         return self._hook("pylsp_hover", doc_uri, position=position) or {"contents": ""}
+
+    def implementations(self, doc_uri, position):
+        return flatten(self._hook("pylsp_implementations", doc_uri, position=position))
 
     @_utils.debounce(LINT_DEBOUNCE_S, keyed_by="doc_uri")
     def lint(self, doc_uri, is_saved) -> None:
@@ -761,6 +765,12 @@ class PythonLSPServer(MethodDispatcher):
         if isinstance(document, Cell):
             return self._cell_document__definition(document, position, **_kwargs)
         return self.definitions(textDocument["uri"], position)
+
+    def m_text_document__implementation(self, textDocument=None, position=None, **_kwargs):
+        # textDocument here is just a dict with a uri
+        workspace = self._match_uri_to_workspace(textDocument["uri"])
+        document = workspace.get_document(textDocument["uri"])
+        return self.implementations(textDocument["uri"], position)
 
     def m_text_document__document_highlight(
         self, textDocument=None, position=None, **_kwargs

--- a/pylsp/python_lsp.py
+++ b/pylsp/python_lsp.py
@@ -768,8 +768,6 @@ class PythonLSPServer(MethodDispatcher):
 
     def m_text_document__implementation(self, textDocument=None, position=None, **_kwargs):
         # textDocument here is just a dict with a uri
-        workspace = self._match_uri_to_workspace(textDocument["uri"])
-        document = workspace.get_document(textDocument["uri"])
         return self.implementations(textDocument["uri"], position)
 
     def m_text_document__document_highlight(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ pyflakes = "pylsp.plugins.pyflakes_lint"
 pylint = "pylsp.plugins.pylint_lint"
 rope_completion = "pylsp.plugins.rope_completion"
 rope_autoimport = "pylsp.plugins.rope_autoimport"
+rope_implementation = "pylsp.plugins.rope_implementation"
 yapf = "pylsp.plugins.yapf_format"
 
 [project.scripts]

--- a/test/data/implementations_examples/example.py
+++ b/test/data/implementations_examples/example.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 
+
 class Animal(ABC):
     @abstractmethod
     def breathe(self):

--- a/test/data/implementations_examples/example.py
+++ b/test/data/implementations_examples/example.py
@@ -1,0 +1,29 @@
+from abc import ABC, abstractmethod
+
+class Animal(ABC):
+    @abstractmethod
+    def breathe(self):
+        pass
+
+    @property
+    @abstractmethod
+    def size(self) -> str:
+        pass
+
+class WingedAnimal(Animal):
+    @abstractmethod
+    def fly(self, destination):
+        pass
+
+class Bird(WingedAnimal):
+    def breathe(self):
+        print("*inhales like a bird*")
+
+    def fly(self, destination):
+        print("*flies like a bird*")
+
+    @property
+    def size(self) -> str:
+        return "bird-sized"
+
+print("not a method at all")

--- a/test/plugins/test_implementations.py
+++ b/test/plugins/test_implementations.py
@@ -5,7 +5,6 @@ import test
 from pathlib import Path
 
 import pytest
-from rope.base.exceptions import BadIdentifierError
 
 from pylsp import uris
 from pylsp.config.config import Config
@@ -74,7 +73,7 @@ def test_implementations_skipping_one_class(config, workspace, doc_uri) -> None:
 
 
 @pytest.mark.xfail(
-    reason="not implemented upstream (Rope)", strict=True, raises=BadIdentifierError
+    reason="not implemented upstream (Rope)", strict=True, raises=AssertionError
 )
 def test_property_implementations(config, workspace, doc_uri) -> None:
     # Over 'Animal.size'
@@ -93,12 +92,11 @@ def test_property_implementations(config, workspace, doc_uri) -> None:
 
 
 def test_implementations_not_a_method(config, workspace, doc_uri) -> None:
-    # Over 'print(...)' call => Rope error because not a method.
+    # Over 'print(...)' call
     cursor_pos = {"line": 28, "character": 0}
 
     doc = workspace.get_document(doc_uri)
 
-    # This exception is turned into an empty result set automatically in upper
-    # layers, so we just check that it is raised to document this behavior:
-    with pytest.raises(BadIdentifierError):
-        pylsp_implementations(config, workspace, doc, cursor_pos)
+    # Rope produces an error because we're not over a method, which we then
+    # turn into an empty result list:
+    assert [] == pylsp_implementations(config, workspace, doc, cursor_pos)

--- a/test/plugins/test_implementations.py
+++ b/test/plugins/test_implementations.py
@@ -1,8 +1,7 @@
 # Copyright 2017-2020 Palantir Technologies, Inc.
 # Copyright 2021- Python Language Server Contributors.
 
-from collections.abc import Iterable
-from importlib.resources import as_file, files
+import test
 from pathlib import Path
 
 import pytest
@@ -21,9 +20,10 @@ from pylsp.workspace import Workspace
 # An alternative to using real files would be `unittest.mock.patch`, but that
 # ends up being more trouble than it's worth...
 @pytest.fixture
-def examples_dir_path() -> Iterable[Path]:
-    with as_file(files("test.data.implementations_examples")) as path:
-        yield path
+def examples_dir_path() -> Path:
+    # In Python 3.12+, this should be obtained using `importlib.resources`,
+    # but as we need to support older versions, we do it the hacky way:
+    return Path(test.__file__).parent / "data/implementations_examples"
 
 
 @pytest.fixture

--- a/test/plugins/test_implementations.py
+++ b/test/plugins/test_implementations.py
@@ -1,0 +1,142 @@
+# Copyright 2017-2020 Palantir Technologies, Inc.
+# Copyright 2021- Python Language Server Contributors.
+
+import os
+
+import pytest
+
+from pylsp import uris
+from pylsp.plugins.rope_implementation import pylsp_implementations
+from pylsp.workspace import Document
+
+DOC_URI = uris.from_fs_path(__file__)
+DOC = """
+from abc import ABC, abstractmethod
+
+class Animal(ABC):
+    @abstractmethod
+    def breathe(self):
+        ...
+
+    @property
+    @abstractmethod
+    def size(self) -> str:
+        ...
+
+class WingedAnimal(Animal):
+    @abstractmethod
+    def fly(self, destination):
+        ...
+
+class Bird(WingedAnimal):
+    def breathe(self):
+        print("*inhales like a bird*")
+
+    def fly(self, destination):
+        print("*flies like a bird*")
+
+    @property
+    def size(self) -> str:
+        return "bird-sized"
+
+print("not a method at all")
+"""
+
+
+def test_implementations(config, workspace) -> None:
+    # Over 'fly' in WingedAnimal.fly
+    cursor_pos = {"line": 15, "character": 9}
+
+    # The implementation of 'Bird.fly'
+    def_range = {
+        "start": {"line": 22, "character": 0},
+        "end": {"line": 22, "character": 999},
+    }
+
+    workspace.put_document(DOC_URI, DOC)
+    doc = workspace.get_document(DOC_URI)
+    assert [{"uri": DOC_URI, "range": def_range}] == pylsp_implementations(
+        config, workspace, doc, cursor_pos
+    )
+
+
+def test_implementations_skipping_one_class(config, workspace) -> None:
+    # Over 'Animal.breathe'
+    cursor_pos = {"line": 15, "character": 9}
+
+    # The implementation of 'breathe', skipping intermediate classes
+    def_range = {
+        "start": {"line": 19, "character": 0},
+        "end": {"line": 19, "character": 999},
+    }
+
+    doc = Document(DOC_URI, workspace, DOC)
+    assert [{"uri": DOC_URI, "range": def_range}] == pylsp_implementations(
+        config, workspace, doc, cursor_pos
+    )
+
+
+@pytest.mark.xfail(reason="not implemented upstream (Rope)", strict=True)
+def test_property_implementations(config, workspace) -> None:
+    # Over 'Animal.size'
+    cursor_pos = {"line": 10, "character": 9}
+
+    # The property implementation 'Bird.size'
+    def_range = {
+        "start": {"line": 26, "character": 0},
+        "end": {"line": 26, "character": 999},
+    }
+
+    doc = Document(DOC_URI, workspace, DOC)
+    assert [{"uri": DOC_URI, "range": def_range}] == pylsp_implementations(
+        config, workspace, doc, cursor_pos
+    )
+
+
+def test_no_implementations_if_not_a_method(config, workspace) -> None:
+    # Over 'print(...)' call
+    cursor_pos = {"line": 26, "character": 0}
+
+    doc = Document(DOC_URI, workspace, DOC)
+    assert [] == pylsp_implementations(config, workspace, doc, cursor_pos)
+
+
+def test_document_path_implementations(
+    config, workspace, workspace_other_root_path, tmpdir
+) -> None:
+    # Create a dummy module out of the workspace's root_path and try to get
+    # a implementation on it in another file placed next to it.
+    module_content = """
+class A:
+    def f():
+"""
+
+    p = tmpdir.join("mymodule.py")
+    p.write(module_content)
+
+    # Content of doc to test implementation
+    doc_content = """
+from mymodule import A
+class B(A):
+    def f():
+"""
+    doc_path = str(tmpdir) + os.path.sep + "myfile.py"
+    doc_uri = uris.from_fs_path(doc_path)
+    doc = Document(doc_uri, workspace_other_root_path, doc_content)
+
+    # The range where f is defined in mymodule.py
+    def_range = {
+        "start": {"line": 2, "character": 0},
+        "end": {"line": 2, "character": 999},
+    }
+
+    # The position where foo is called in myfile.py
+    cursor_pos = {"line": 3, "character": 9}
+
+    # The uri for mymodule.py
+    module_path = str(p)
+    module_uri = uris.from_fs_path(module_path)
+
+    assert [{"uri": module_uri, "range": def_range}] == pylsp_implementations(
+        config, workspace, doc, cursor_pos
+    )

--- a/test/plugins/test_implementations.py
+++ b/test/plugins/test_implementations.py
@@ -47,8 +47,8 @@ def test_implementations(config, workspace, doc_uri) -> None:
 
     # The implementation of 'Bird.fly'
     def_range = {
-        "start": {"line": 21, "character": 0},
-        "end": {"line": 21, "character": 999},
+        "start": {"line": 21, "character": 8},
+        "end": {"line": 21, "character": 11},
     }
 
     doc = workspace.get_document(doc_uri)
@@ -63,8 +63,8 @@ def test_implementations_skipping_one_class(config, workspace, doc_uri) -> None:
 
     # The implementation of 'breathe', skipping intermediate classes
     def_range = {
-        "start": {"line": 18, "character": 0},
-        "end": {"line": 18, "character": 999},
+        "start": {"line": 18, "character": 8},
+        "end": {"line": 18, "character": 15},
     }
 
     doc = workspace.get_document(doc_uri)
@@ -82,8 +82,8 @@ def test_property_implementations(config, workspace, doc_uri) -> None:
 
     # The property implementation 'Bird.size'
     def_range = {
-        "start": {"line": 25, "character": 0},
-        "end": {"line": 25, "character": 999},
+        "start": {"line": 25, "character": 8},
+        "end": {"line": 25, "character": 12},
     }
 
     doc = workspace.get_document(doc_uri)

--- a/test/plugins/test_implementations.py
+++ b/test/plugins/test_implementations.py
@@ -1,11 +1,11 @@
 # Copyright 2017-2020 Palantir Technologies, Inc.
 # Copyright 2021- Python Language Server Contributors.
 
-import test
 from pathlib import Path
 
 import pytest
 
+import test
 from pylsp import uris
 from pylsp.config.config import Config
 from pylsp.plugins.rope_implementation import pylsp_implementations
@@ -42,12 +42,12 @@ def workspace(examples_dir_path: Path, endpoint) -> None:
 
 def test_implementations(config, workspace, doc_uri) -> None:
     # Over 'fly' in WingedAnimal.fly
-    cursor_pos = {"line": 14, "character": 8}
+    cursor_pos = {"line": 15, "character": 8}
 
     # The implementation of 'Bird.fly'
     def_range = {
-        "start": {"line": 21, "character": 8},
-        "end": {"line": 21, "character": 11},
+        "start": {"line": 22, "character": 8},
+        "end": {"line": 22, "character": 11},
     }
 
     doc = workspace.get_document(doc_uri)
@@ -58,12 +58,12 @@ def test_implementations(config, workspace, doc_uri) -> None:
 
 def test_implementations_skipping_one_class(config, workspace, doc_uri) -> None:
     # Over 'Animal.breathe'
-    cursor_pos = {"line": 4, "character": 8}
+    cursor_pos = {"line": 5, "character": 8}
 
     # The implementation of 'breathe', skipping intermediate classes
     def_range = {
-        "start": {"line": 18, "character": 8},
-        "end": {"line": 18, "character": 15},
+        "start": {"line": 19, "character": 8},
+        "end": {"line": 19, "character": 15},
     }
 
     doc = workspace.get_document(doc_uri)
@@ -77,12 +77,12 @@ def test_implementations_skipping_one_class(config, workspace, doc_uri) -> None:
 )
 def test_property_implementations(config, workspace, doc_uri) -> None:
     # Over 'Animal.size'
-    cursor_pos = {"line": 9, "character": 9}
+    cursor_pos = {"line": 10, "character": 9}
 
     # The property implementation 'Bird.size'
     def_range = {
-        "start": {"line": 25, "character": 8},
-        "end": {"line": 25, "character": 12},
+        "start": {"line": 26, "character": 8},
+        "end": {"line": 26, "character": 12},
     }
 
     doc = workspace.get_document(doc_uri)
@@ -93,7 +93,7 @@ def test_property_implementations(config, workspace, doc_uri) -> None:
 
 def test_implementations_not_a_method(config, workspace, doc_uri) -> None:
     # Over 'print(...)' call
-    cursor_pos = {"line": 28, "character": 0}
+    cursor_pos = {"line": 29, "character": 0}
 
     doc = workspace.get_document(doc_uri)
 

--- a/test/plugins/test_implementations.py
+++ b/test/plugins/test_implementations.py
@@ -1,142 +1,104 @@
 # Copyright 2017-2020 Palantir Technologies, Inc.
 # Copyright 2021- Python Language Server Contributors.
 
-import os
+from collections.abc import Iterable
+from importlib.resources import as_file, files
+from pathlib import Path
 
 import pytest
+from rope.base.exceptions import BadIdentifierError
 
 from pylsp import uris
+from pylsp.config.config import Config
 from pylsp.plugins.rope_implementation import pylsp_implementations
-from pylsp.workspace import Document
-
-DOC_URI = uris.from_fs_path(__file__)
-DOC = """
-from abc import ABC, abstractmethod
-
-class Animal(ABC):
-    @abstractmethod
-    def breathe(self):
-        ...
-
-    @property
-    @abstractmethod
-    def size(self) -> str:
-        ...
-
-class WingedAnimal(Animal):
-    @abstractmethod
-    def fly(self, destination):
-        ...
-
-class Bird(WingedAnimal):
-    def breathe(self):
-        print("*inhales like a bird*")
-
-    def fly(self, destination):
-        print("*flies like a bird*")
-
-    @property
-    def size(self) -> str:
-        return "bird-sized"
-
-print("not a method at all")
-"""
+from pylsp.workspace import Workspace
 
 
-def test_implementations(config, workspace) -> None:
+# We use a real file because the part of Rope that this feature uses
+# (`rope.findit.find_implementations`) *always* loads files from the
+# filesystem, in contrast to e.g. `code_assist` which takes a `source` argument
+# that can be more easily faked.
+# An alternative to using real files would be `unittest.mock.patch`, but that
+# ends up being more trouble than it's worth...
+@pytest.fixture
+def examples_dir_path() -> Iterable[Path]:
+    with as_file(files("test.data.implementations_examples")) as path:
+        yield path
+
+
+@pytest.fixture
+def doc_uri(examples_dir_path: Path) -> str:
+    return uris.from_fs_path(str(examples_dir_path / "example.py"))
+
+
+# Similarly to the above, we need our workspace to point to the actual location
+# on the filesystem containing the example modules, so we override the fixture:
+@pytest.fixture
+def workspace(examples_dir_path: Path, endpoint) -> None:
+    ws = Workspace(uris.from_fs_path(str(examples_dir_path)), endpoint)
+    ws._config = Config(ws.root_uri, {}, 0, {})
+    yield ws
+    ws.close()
+
+
+def test_implementations(config, workspace, doc_uri) -> None:
     # Over 'fly' in WingedAnimal.fly
-    cursor_pos = {"line": 15, "character": 9}
+    cursor_pos = {"line": 14, "character": 8}
 
     # The implementation of 'Bird.fly'
     def_range = {
-        "start": {"line": 22, "character": 0},
-        "end": {"line": 22, "character": 999},
+        "start": {"line": 21, "character": 0},
+        "end": {"line": 21, "character": 999},
     }
 
-    workspace.put_document(DOC_URI, DOC)
-    doc = workspace.get_document(DOC_URI)
-    assert [{"uri": DOC_URI, "range": def_range}] == pylsp_implementations(
+    doc = workspace.get_document(doc_uri)
+    assert [{"uri": doc_uri, "range": def_range}] == pylsp_implementations(
         config, workspace, doc, cursor_pos
     )
 
 
-def test_implementations_skipping_one_class(config, workspace) -> None:
+def test_implementations_skipping_one_class(config, workspace, doc_uri) -> None:
     # Over 'Animal.breathe'
-    cursor_pos = {"line": 15, "character": 9}
+    cursor_pos = {"line": 4, "character": 8}
 
     # The implementation of 'breathe', skipping intermediate classes
     def_range = {
-        "start": {"line": 19, "character": 0},
-        "end": {"line": 19, "character": 999},
+        "start": {"line": 18, "character": 0},
+        "end": {"line": 18, "character": 999},
     }
 
-    doc = Document(DOC_URI, workspace, DOC)
-    assert [{"uri": DOC_URI, "range": def_range}] == pylsp_implementations(
+    doc = workspace.get_document(doc_uri)
+    assert [{"uri": doc_uri, "range": def_range}] == pylsp_implementations(
         config, workspace, doc, cursor_pos
     )
 
 
-@pytest.mark.xfail(reason="not implemented upstream (Rope)", strict=True)
-def test_property_implementations(config, workspace) -> None:
+@pytest.mark.xfail(
+    reason="not implemented upstream (Rope)", strict=True, raises=BadIdentifierError
+)
+def test_property_implementations(config, workspace, doc_uri) -> None:
     # Over 'Animal.size'
-    cursor_pos = {"line": 10, "character": 9}
+    cursor_pos = {"line": 9, "character": 9}
 
     # The property implementation 'Bird.size'
     def_range = {
-        "start": {"line": 26, "character": 0},
-        "end": {"line": 26, "character": 999},
+        "start": {"line": 25, "character": 0},
+        "end": {"line": 25, "character": 999},
     }
 
-    doc = Document(DOC_URI, workspace, DOC)
-    assert [{"uri": DOC_URI, "range": def_range}] == pylsp_implementations(
+    doc = workspace.get_document(doc_uri)
+    assert [{"uri": doc_uri, "range": def_range}] == pylsp_implementations(
         config, workspace, doc, cursor_pos
     )
 
 
-def test_no_implementations_if_not_a_method(config, workspace) -> None:
-    # Over 'print(...)' call
-    cursor_pos = {"line": 26, "character": 0}
+def test_implementations_not_a_method(config, workspace, doc_uri) -> None:
+    # Over 'print(...)' call => Rope error because not a method.
+    cursor_pos = {"line": 28, "character": 0}
 
-    doc = Document(DOC_URI, workspace, DOC)
-    assert [] == pylsp_implementations(config, workspace, doc, cursor_pos)
+    doc = workspace.get_document(doc_uri)
 
-
-def test_document_path_implementations(
-    config, workspace, workspace_other_root_path, tmpdir
-) -> None:
-    # Create a dummy module out of the workspace's root_path and try to get
-    # a implementation on it in another file placed next to it.
-    module_content = """
-class A:
-    def f():
-"""
-
-    p = tmpdir.join("mymodule.py")
-    p.write(module_content)
-
-    # Content of doc to test implementation
-    doc_content = """
-from mymodule import A
-class B(A):
-    def f():
-"""
-    doc_path = str(tmpdir) + os.path.sep + "myfile.py"
-    doc_uri = uris.from_fs_path(doc_path)
-    doc = Document(doc_uri, workspace_other_root_path, doc_content)
-
-    # The range where f is defined in mymodule.py
-    def_range = {
-        "start": {"line": 2, "character": 0},
-        "end": {"line": 2, "character": 999},
-    }
-
-    # The position where foo is called in myfile.py
-    cursor_pos = {"line": 3, "character": 9}
-
-    # The uri for mymodule.py
-    module_path = str(p)
-    module_uri = uris.from_fs_path(module_path)
-
-    assert [{"uri": module_uri, "range": def_range}] == pylsp_implementations(
-        config, workspace, doc, cursor_pos
-    )
+    # This exception is turned into an empty result set automatically in upper
+    # layers, so we just check that it is raised to document this behavior:
+    with pytest.raises(BadIdentifierError):
+        pylsp_implementations(config, workspace, doc, cursor_pos)


### PR DESCRIPTION
# Description

As pointed out in #97, support for the LSP [Goto Implementation Request](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_implementation) (`textDocument/implementation`) aka `implementationProvider` capability is still missing.

This PR adds basic support for this feature using Rope's `rope.findit.find_implementations` function (so it only works if the `rope` extra is installed).

Rope's `find_implementations` function seems a bit brittle, e.g. it doesn't appear to work for some slightly more complicated inheritance hierarchies (multiple levels & multiple inheritance & generics, but not sure _which_ of these is the issue), but these things should be fixed upstream & in any case it's better than nothing.

# Status

- Blocked by:
  - https://github.com/python-rope/rope/issues/812
- Also at least 1 bug remaining on this side of the implementation:
  - https://github.com/python-lsp/python-lsp-server/pull/644#discussion_r2085439327