### PR TITLE
Enforce `setuptools` 69 or newer to ensure `py.typed` marker gets included

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Copyright 2021- Python Language Server Contributors.
 
 [build-system]
-requires = ["setuptools>=61.2.0", "setuptools_scm[toml]>=3.4.3"]
+requires = ["setuptools>=69.0.0", "setuptools_scm[toml]>=3.4.3"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
See:
- discussion in https://github.com/python-lsp/python-lsp-server/pull/641
- upstream PR https://github.com/pypa/setuptools/pull/4021