### PR TITLE
Add funding-manifest-urls for FLOSS fund

### DIFF
--- a/.well-known/funding-manifest-urls
+++ b/.well-known/funding-manifest-urls
@@ -1,0 +1,1 @@
+https://www.spyder-ide.org/funding.json


### PR DESCRIPTION
Adds the `.well-known/funding-manifest-urls` file required to validate that our `funding.json` on the Spyder website for the FLOSS fund represents this repo.