### PR TITLE
Copy `LAST_JEDI_COMPLETIONS` to cell document so that `completionItem/resolve` will work

### DIFF
--- a/pylsp/python_lsp.py
+++ b/pylsp/python_lsp.py
@@ -722,6 +722,10 @@ class PythonLSPServer(MethodDispatcher):
                 if item.get("data", {}).get("doc_uri") == temp_uri:
                     item["data"]["doc_uri"] = cellDocument.uri
 
+            # Copy LAST_JEDI_COMPLETIONS to cell document so that completionItem/resolve will work
+            tempDocument = workspace.get_document(temp_uri)
+            cellDocument.shared_data["LAST_JEDI_COMPLETIONS"] = tempDocument.shared_data.get("LAST_JEDI_COMPLETIONS", None)
+
             return completions
 
     def m_text_document__completion(self, textDocument=None, position=None, **_kwargs):

--- a/pylsp/python_lsp.py
+++ b/pylsp/python_lsp.py
@@ -724,7 +724,9 @@ class PythonLSPServer(MethodDispatcher):
 
             # Copy LAST_JEDI_COMPLETIONS to cell document so that completionItem/resolve will work
             tempDocument = workspace.get_document(temp_uri)
-            cellDocument.shared_data["LAST_JEDI_COMPLETIONS"] = tempDocument.shared_data.get("LAST_JEDI_COMPLETIONS", None)
+            cellDocument.shared_data["LAST_JEDI_COMPLETIONS"] = (
+                tempDocument.shared_data.get("LAST_JEDI_COMPLETIONS", None)
+            )
 
             return completions
 


### PR DESCRIPTION
Let's say I am running this LSP server with Ruff (for linting) and Jedi (for autocompletion, with eager off). I then open a notebook document with a few cells in it.

I open the document (and the cells) with the `notebookDocument/didOpen` method.

Now, I request completion using the method `textDocument/completion` and receive the completion items as expected.

So far, so good.

Now, if I attempt to resolve one of the completion items using the `completionItem/resolve` method, I receive an empty array as a result.

This issue occurs because PyLSP concatenates cells of notebook documents into a temporary document and then uses it to generate completion items. That temporary document has a "randomly" generated UUID as its URI. When generating completion items, the shared data "LAST_JEDI_COMPLETIONS" is stored on this temporary document.

However, when the client sends back any "completion item" to be resolved, it looks for "LAST_JEDI_COMPLETIONS" shared data on the actual cell document, where this shared data is not present, and the request to "resolve" fails.

This PR copies the "LAST_JEDI_COMPLETIONS" shared data from the temporary document to the cell document at the end of the "completion" request.