### PR TITLE
Prevent creating empty .ropeproject with null conf

### DIFF
--- a/pylsp/workspace.py
+++ b/pylsp/workspace.py
@@ -78,7 +78,7 @@ class Workspace:
         # TODO: we could keep track of dirty files and validate only those
         if self.__rope is None or self.__rope_config != rope_config:
             rope_folder = rope_config.get("ropeFolder")
-            if "ropeFolder" in rope_config:
+            if rope_folder is not None:
                 self.__rope = Project(self._root_path, ropefolder=rope_folder)
             else:
                 self.__rope = Project(self._root_path)


### PR DESCRIPTION
When `ropeFolder` is defined in the configuration but set to null (as would happen with a default config generated by e.g. Zed editing a python file), avoid creating an empty and unused `.ropeproject` directory. This change completes what I think was the goal of  https://github.com/python-lsp/python-lsp-server/pull/604/files, where `"ropeFolder": null` in the configuration still generates an empty and unused `.ropeproject` folder.