### PR TITLE
Expose a shutdown hook

### DIFF
--- a/pylsp/hookspecs.py
+++ b/pylsp/hookspecs.py
@@ -138,3 +138,8 @@ def pylsp_signature_help(config, workspace, document, position) -> None:
 @hookspec
 def pylsp_workspace_configuration_changed(config, workspace) -> None:
     pass
+
+
+@hookspec
+def pylsp_shutdown(config, workspace) -> None:
+    pass

--- a/pylsp/python_lsp.py
+++ b/pylsp/python_lsp.py
@@ -237,6 +237,7 @@ class PythonLSPServer(MethodDispatcher):
     def m_shutdown(self, **_kwargs) -> None:
         for workspace in self.workspaces.values():
             workspace.close()
+        self._hook("pylsp_shutdown")
         self._shutdown = True
 
     def m_invalid_request_after_shutdown(self, **_kwargs):


### PR DESCRIPTION
This allows plugins to perform some operations (e.g. terminating a daemon process or cleaning temporary resources) upon LSP server shutdown.
* * *
For instance, this could be useful for pylsp-mypy which currently already does some temporary file cleanup through an atexit hook but would also need to terminate mypy daemon when LSP exits in order to avoid dangling processes. See https://github.com/python-lsp/pylsp-mypy/issues/88