### PR TITLE
Use PyQt6 for testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ test = [
     "numpy",
     "pandas",
     "matplotlib",
-    "pyqt5",
+    "pyqt6",
     "flaky",
     "websockets>=10.3",
 ]

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -282,8 +282,8 @@ def test_jedi_method_completion(config, workspace) -> None:
     reason="Test in Python 3 and not on CIs on Linux because wheels don't work on them.",
 )
 def test_pyqt_completion(config, workspace) -> None:
-    # Over 'QA' in 'from PyQt5.QtWidgets import QApplication'
-    doc_pyqt = "from PyQt5.QtWidgets import QA"
+    # Over 'QA' in 'from PyQt6.QtWidgets import QApplication'
+    doc_pyqt = "from PyQt6.QtWidgets import QA"
     com_position = {"line": 0, "character": len(doc_pyqt)}
     doc = Document(DOC_URI, workspace, doc_pyqt)
     completions = pylsp_jedi_completions(config, doc, com_position)


### PR DESCRIPTION
Qt5 is past its EOL and downstream distributions are working on removing it from their repositories.

This dependency is only used in a test, so it doesn't affect dependencies or functionality for end users.