### PR TITLE
Fix license entries in `pyproject.toml` due to pep 639

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 [![image](https://github.com/python-ls/python-ls/workflows/Linux%20tests/badge.svg)](https://github.com/python-ls/python-ls/actions?query=workflow%3A%22Linux+tests%22) [![image](https://github.com/python-ls/python-ls/workflows/Mac%20tests/badge.svg)](https://github.com/python-ls/python-ls/actions?query=workflow%3A%22Mac+tests%22) [![image](https://github.com/python-ls/python-ls/workflows/Windows%20tests/badge.svg)](https://github.com/python-ls/python-ls/actions?query=workflow%3A%22Windows+tests%22) [![image](https://img.shields.io/github/license/python-ls/python-ls.svg)](https://github.com/python-ls/python-ls/blob/master/LICENSE)
 
-A Python 3.8+ implementation of the [Language Server Protocol](https://github.com/Microsoft/language-server-protocol).
-(Note: versions <1.4 should still work with Python 3.6)
+A Python 3.9+ implementation of the [Language Server Protocol](https://github.com/Microsoft/language-server-protocol).
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ name = "python-lsp-server"
 authors = [{name = "Python Language Server Contributors"}]
 description = "Python Language Server for the Language Server Protocol"
 readme = "README.md"
-license = {text = "MIT"}
+license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.9"
 dependencies = [
     "docstring-to-markdown",
@@ -170,7 +171,6 @@ docstring-code-format = false
 docstring-code-line-length = "dynamic"
 
 [tool.setuptools]
-license-files = ["LICENSE"]
 include-package-data = false
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Also, fix minimal supported Python version in Readme