### PR TITLE
Include None value from second object while merging dicts 

### DIFF
--- a/pylsp/_utils.py
+++ b/pylsp/_utils.py
@@ -167,6 +167,8 @@ def merge_dicts(dict_a, dict_b):
                     yield (key, a[key])
             elif key in a:
                 yield (key, a[key])
+            elif key in b and key not in a:
+                yield (key, b[key])
             elif b[key] is not None:
                 yield (key, b[key])
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -202,6 +202,22 @@ def test_merge_dicts() -> None:
         {"a": True, "b": {"x": 123, "y": {"hello": "world"}}},
         {"a": False, "b": {"y": [], "z": 987}},
     ) == {"a": False, "b": {"x": 123, "y": [], "z": 987}}
+    assert _utils.merge_dicts(
+        {"a": True, "b": "foo"},
+        {"c": None}
+    ) == {"a": True, "b": "foo", "c": None}, "None value for key that is only in second object should be preserved"
+    assert _utils.merge_dicts(
+        {"a": None, "b": "foo"},
+        {"b": "bar"}
+    ) == {"a": None, "b": "bar"}, "None value for key that is only in first object should be preserved"
+    assert _utils.merge_dicts(
+        {"a": True, "b": "foo"},
+        {"b": None, }
+    ) == {"a": True, "b": "foo"}, "None value for key in second object should not override the value in first object"
+    assert _utils.merge_dicts(
+        {"a": True, "b": {"bar": "baz"}},
+        {"b": {"bar": "baz", "foo": None}, }
+    ) == {"a": True, "b": {"bar": "baz", "foo": None}}, "Nested None value for key that is only in second object should be preserved"
 
 
 def test_clip_column() -> None:


### PR DESCRIPTION
This commit includes None value in merged output dict for keys that only exist in second input dict (also while nested).
The original logic is preserving a[key] value if b[key] is None, this remains unchanged.

Added test cases for this behavior.

Context:
This function is used while getting Config.settings.
As per [CONFIGURATION.md](https://github.com/python-lsp/python-lsp-server/blob/develop/CONFIGURATION.md) `pylsp.rope.ropeFolder` can be a null value.
When configuration is received from the client, it is correctly parsed to None value, thus the
`config._settings["rope"]["ropeFolder] = None`.
Once merged the output settings["rope"] dict didn't contain key "ropeFolder".

I believe that merge dict was behaving correctly if "rope" key didn't exist however when workspace/didChangeConfiguration got sent and "rope" key did exist with dict containing "extensionModules" list, in my case, the "ropeFolder" was completely ignored by `merge_dicts`

This will fix #664 and I believe #622 

Fyi @osiewicz 