### PR TITLE
Prevent showing cmd on Windows when running flake8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,7 @@ ENV/
 
 # Spyder project settings
 .spyderproject
+.spyproject
 
 # Rope project settings
 .ropeproject

--- a/pylsp/plugins/flake8_lint.py
+++ b/pylsp/plugins/flake8_lint.py
@@ -34,6 +34,13 @@ ERROR_CODES = (
     | {"E999"}
 )
 
+if sys.platform == "win32":
+    from subprocess import CREATE_NO_WINDOW
+else:
+    # CREATE_NO_WINDOW flag only available on Windows.
+    # Set constant as default `Popen` `creationflag` kwarg value (`0`)
+    CREATE_NO_WINDOW = 0
+
 
 @hookimpl
 def pylsp_settings():
@@ -128,7 +135,7 @@ def run_flake8(flake8_executable, args, document, source):
         )
 
     log.debug("Calling %s with args: '%s'", flake8_executable, args)
-    popen_kwargs = {}
+    popen_kwargs = {"creationflags": CREATE_NO_WINDOW}
     if cwd := document._workspace.root_path:
         popen_kwargs["cwd"] = cwd
     try:


### PR DESCRIPTION
Using the flake8 plugin on Windows with Spyder causes cmd windows to appear. Seems like adding the `Popen.CREATE_NO_WINDOW` flag to the Popen calls that run the flake8 executable help.

Addresses https://github.com/spyder-ide/spyder/issues/25195