### PR TITLE
Adjust test based on Jedi version

### DIFF
--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -181,7 +181,7 @@ def test_jedi_completion_with_fuzzy_enabled(config, workspace) -> None:
 
     assert items
 
-    expected = "isabs(s)"
+    expected = "commonprefix(m)" if JEDI_VERSION < "0.19.2" else "isabs(s)"
     assert items[0]["label"] == expected
 
     # Test we don't throw with big character


### PR DESCRIPTION
The current supported versions of jedi supported by the project as stated in pyproject.py are "jedi>=0.17.2,<0.20.0", but the unit tests are currently passing only for jedi >=0.19.2 (see PR #609).

When packaging python-lsp-server 1.13.2 to debian, this very same change was required as the current debian version of jedi is 0.19.1. The patch can be seen here:  [debian/patches/0003-Fix-test-to-work-with-jedi-0.19.1.patch]( https://sources.debian.org/src/python-lsp-server/1.13.2-1/debian/patches/0003-Fix-test-to-work-with-jedi-0.19.1.patch)