### PR TITLE
docs: add pylsp-workspace-symbols to third-party plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Installing these plugins will add extra functionality to the language server:
 - [pyls-memestra](https://github.com/QuantStack/pyls-memestra): detecting the use of deprecated APIs.
 - [pylsp-rope](https://github.com/python-rope/pylsp-rope): Extended refactoring capabilities using [Rope](https://github.com/python-rope/rope).
 - [python-lsp-ruff](https://github.com/python-lsp/python-lsp-ruff): Extensive and fast linting using [ruff](https://github.com/charliermarsh/ruff).
+- [pylsp-workspace-symbols](https://github.com/Hanatarou/pylsp-workspace-symbols): Workspace symbol search support using [Jedi](https://github.com/davidhalter/jedi).
 
 Please see the above repositories for examples on how to write plugins for the Python LSP Server.
 


### PR DESCRIPTION
Add [pylsp-workspace-symbols](https://github.com/Hanatarou/pylsp-workspace-symbols) to the third-party plugins list.

This plugin provides  support via Jedi, addressing a long-standing feature request (#237, #564, #511) while those issues are pending merge.

**Features:**
- Uses  to advertise 
- Uses  to register a custom  handler  
- Calls  with filtering by case-insensitive substring match
- Automatically skips noise folders (, , , etc.)

**Install:**
Collecting pylsp-workspace-symbols
  Downloading pylsp_workspace_symbols-0.6.0-py3-none-any.whl.metadata (21 kB)
Collecting python-lsp-server>=1.7 (from pylsp-workspace-symbols)
  Downloading python_lsp_server-1.14.0-py3-none-any.whl.metadata (10 kB)
Requirement already satisfied: jedi>=0.18 in /usr/local/lib/python3.11/dist-packages (from pylsp-workspace-symbols) (0.19.1)
Requirement already satisfied: parso<0.9.0,>=0.8.3 in /usr/local/lib/python3.11/dist-packages (from jedi>=0.18->pylsp-workspace-symbols) (0.8.4)
Collecting docstring-to-markdown (from python-lsp-server>=1.7->pylsp-workspace-symbols)
  Downloading docstring_to_markdown-0.17-py3-none-any.whl.metadata (2.3 kB)
Requirement already satisfied: pluggy>=1.0.0 in /usr/local/lib/python3.11/dist-packages (from python-lsp-server>=1.7->pylsp-workspace-symbols) (1.6.0)
Collecting python-lsp-jsonrpc<2.0.0,>=1.1.0 (from python-lsp-server>=1.7->pylsp-workspace-symbols)
  Downloading python_lsp_jsonrpc-1.1.2-py3-none-any.whl.metadata (1.5 kB)
Collecting ujson>=3.0.0 (from python-lsp-server>=1.7->pylsp-workspace-symbols)
  Downloading ujson-5.12.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl.metadata (9.6 kB)
Requirement already satisfied: black in /usr/local/lib/python3.11/dist-packages (from python-lsp-server>=1.7->pylsp-workspace-symbols) (25.12.0)
Requirement already satisfied: click>=8.0.0 in /usr/local/lib/python3.11/dist-packages (from black->python-lsp-server>=1.7->pylsp-workspace-symbols) (8.3.1)
Requirement already satisfied: mypy-extensions>=0.4.3 in /usr/local/lib/python3.11/dist-packages (from black->python-lsp-server>=1.7->pylsp-workspace-symbols) (1.1.0)
Requirement already satisfied: packaging>=22.0 in /usr/local/lib/python3.11/dist-packages (from black->python-lsp-server>=1.7->pylsp-workspace-symbols) (24.1)
Requirement already satisfied: pathspec>=0.9.0 in /usr/local/lib/python3.11/dist-packages (from black->python-lsp-server>=1.7->pylsp-workspace-symbols) (1.0.4)
Requirement already satisfied: platformdirs>=2 in /usr/local/lib/python3.11/dist-packages (from black->python-lsp-server>=1.7->pylsp-workspace-symbols) (4.3.6)
Requirement already satisfied: pytokens>=0.3.0 in /usr/local/lib/python3.11/dist-packages (from black->python-lsp-server>=1.7->pylsp-workspace-symbols) (0.4.1)
Requirement already satisfied: importlib-metadata>=3.6 in /usr/local/lib/python3.11/dist-packages (from docstring-to-markdown->python-lsp-server>=1.7->pylsp-workspace-symbols) (8.7.1)
Requirement already satisfied: typing_extensions>=4.6 in /usr/local/lib/python3.11/dist-packages (from docstring-to-markdown->python-lsp-server>=1.7->pylsp-workspace-symbols) (4.15.0)
Requirement already satisfied: zipp>=3.20 in /usr/local/lib/python3.11/dist-packages (from importlib-metadata>=3.6->docstring-to-markdown->python-lsp-server>=1.7->pylsp-workspace-symbols) (3.23.0)
Downloading pylsp_workspace_symbols-0.6.0-py3-none-any.whl (53 kB)
Downloading python_lsp_server-1.14.0-py3-none-any.whl (77 kB)
Downloading python_lsp_jsonrpc-1.1.2-py3-none-any.whl (8.8 kB)
Downloading ujson-5.12.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl (57 kB)
Downloading docstring_to_markdown-0.17-py3-none-any.whl (23 kB)
Installing collected packages: ujson, python-lsp-jsonrpc, docstring-to-markdown, python-lsp-server, pylsp-workspace-symbols
Successfully installed docstring-to-markdown-0.17 pylsp-workspace-symbols-0.6.0 python-lsp-jsonrpc-1.1.2 python-lsp-server-1.14.0 ujson-5.12.0

Fixes #699