### PR TITLE
deps: replace deprecated ujson with orjson

### DIFF
--- a/pylsp/__main__.py
+++ b/pylsp/__main__.py
@@ -8,7 +8,7 @@ import sys
 import time
 
 try:
-    import ujson as json
+    import orjson as json
 except Exception:
     import json
 

--- a/pylsp/plugins/pylint_lint.py
+++ b/pylsp/plugins/pylint_lint.py
@@ -15,7 +15,7 @@ from subprocess import PIPE, Popen
 from pylsp import hookimpl, lsp
 
 try:
-    import ujson as json
+    import orjson as json
 except Exception:
     import json
 

--- a/pylsp/python_lsp.py
+++ b/pylsp/python_lsp.py
@@ -11,7 +11,7 @@ from functools import partial
 from typing import Any
 
 try:
-    import ujson as json
+    import orjson as json
 except Exception:
     import json
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "jedi>=0.17.2,<0.20.0",
     "pluggy>=1.0.0",
     "python-lsp-jsonrpc>=1.1.0,<2.0.0",
-    "ujson>=3.0.0",
+    "orjson>=3.0.0",
     "black"
 ]
 dynamic = ["version"]


### PR DESCRIPTION
Replace deprecated ujson with orjson as recommended.

UJSON is no longer recommended. The suggested replacement is orjson.

**Changes:**
- pyproject.toml: update dependency
- pylsp/__main__.py: import orjson
- pylsp/plugins/pylint_lint.py: import orjson  
- pylsp/python_lsp.py: import orjson

Fixes #673