### PR TITLE
Handle cross-mount paths in find_parents

### DIFF
--- a/pylsp/_utils.py
+++ b/pylsp/_utils.py
@@ -96,7 +96,11 @@ def find_parents(root, path, names):
     # Split the relative by directory, generate all the parent directories, then check each of them.
     # This avoids running a loop that has different base-cases for unix/windows
     # e.g. /a/b and /a/b/c/d/e.py -> ['/a/b', 'c', 'd']
-    dirs = [root] + os.path.relpath(os.path.dirname(path), root).split(os.path.sep)
+    try:
+        dirs = [root] + os.path.relpath(os.path.dirname(path), root).split(os.path.sep)
+    except ValueError:
+        log.warning("Path %r not in %r", path, root)
+        return []
 
     # Search each of /a/b/c, /a/b, /a
     while dirs:

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -2,6 +2,7 @@
 # Copyright 2021- Python Language Server Contributors.
 
 import multiprocessing
+import ntpath
 import os
 import sys
 import time
@@ -195,6 +196,19 @@ def test_find_parents(tmpdir) -> None:
     assert _utils.find_parents(tmpdir.strpath, path.strpath, ["test.cfg"]) == [
         test_cfg.strpath
     ]
+
+
+def test_find_parents_handles_cross_mount_paths(monkeypatch) -> None:
+    monkeypatch.setattr(_utils.os, "path", ntpath)
+
+    assert (
+        _utils.find_parents(
+            r"\\server\share1",
+            r"\\server\share2\path.py",
+            ["test.cfg"],
+        )
+        == []
+    )
 
 
 def test_merge_dicts() -> None:


### PR DESCRIPTION
`find_parents()` uses `os.path.commonprefix()` as a guard before calling `os.path.relpath()`, but `commonprefix()` is character-based. On Windows UNC paths such as `\\server\share1` and `\\server\share2\path.py`, the prefix check passes even though the paths are on different mounts, and `relpath()` raises `ValueError`.

This catches that `ValueError` and returns `[]`, matching the existing behavior for paths outside the root. The regression test uses `ntpath` directly so it covers the Windows UNC behavior on any platform.

fixes #705

Tests:
- `python -m pytest -o addopts="" test/test_utils.py::test_find_parents_handles_cross_mount_paths test/test_utils.py::test_find_parents -q`
- `python -m pytest -o addopts="" test/test_utils.py -q`
- `py -3 -m ruff check pylsp/_utils.py test/test_utils.py`