### PR TITLE
Use macOS 14 runner on CI and update Github actions

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -22,13 +22,13 @@ jobs:
       OS: 'linux'
     timeout-minutes: 2
     steps:
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: ~/.cache/pip
           key: static-pip-${{ hashFiles('pyproject.toml') }}
           restore-keys: static-pip-
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.9'
           architecture: 'x64'

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -27,13 +27,13 @@ jobs:
         PYTHON_VERSION: ['3.14', '3.13', '3.12', '3.11', '3.10', '3.9']
     timeout-minutes: 10
     steps:
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-${{ matrix.PYTHON_VERSION }}-pip-${{ hashFiles('pyproject.toml') }}
           restore-keys: ${{ runner.os }}-${{ matrix.PYTHON_VERSION }}-pip-
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.PYTHON_VERSION }}
           architecture: 'x64'

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -24,16 +24,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.14', '3.12', '3.9']
+        PYTHON_VERSION: ['3.14', '3.12', '3.11']
     timeout-minutes: 10
     steps:
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: ~/Library/Caches/pip
           key: ${{ runner.os }}-${{ matrix.PYTHON_VERSION }}-pip-${{ hashFiles('pyproject.toml') }}
           restore-keys: ${{ runner.os }}-${{ matrix.PYTHON_VERSION }}-pip-
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.PYTHON_VERSION }}
           architecture: 'x64'

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   build:
     name: Mac Py${{ matrix.PYTHON_VERSION }}
-    runs-on: macos-13
+    runs-on: macos-14
     env:
       CI: 'true'
       OS: 'macos'

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -27,13 +27,13 @@ jobs:
         PYTHON_VERSION: ['3.14', '3.12', '3.9']
     timeout-minutes: 10
     steps:
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: ~\AppData\Local\pip\Cache
           key: ${{ runner.os }}-${{ matrix.PYTHON_VERSION }}-pip-${{ hashFiles('pyproject.toml') }}
           restore-keys: ${{ runner.os }}-${{ matrix.PYTHON_VERSION }}-pip-
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.PYTHON_VERSION }}
           architecture: 'x64'


### PR DESCRIPTION
The previous version is not supported by Github anymore.