### PR TITLE
Fix extra backtick in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ or Arch Linux
 
 ```
 sudo pacman -S python-lsp-server
-````
+```
 
 Only on Alpine Linux the package is named differently. You can install it there by typing this command in your terminal:
 


### PR DESCRIPTION
## Summary

The Arch Linux installation code block in `README.md` was closed with four backticks (``````) instead of three (```), causing incorrect Markdown rendering. On GitHub, the extra backtick causes the text immediately following the code block ("Only on Alpine Linux...") to be incorrectly rendered as part of the code block rather than as normal prose.

## The Problem

Line 71 of `README.md` contains:

```
sudo pacman -S python-lsp-server
````
```

(notice the four backticks closing the block)

## The Fix

Remove the extra backtick so the code block is properly closed with the standard three-backtick fence:

```diff
-sudo pacman -S python-lsp-server
-````
+sudo pacman -S python-lsp-server
+```
```

This is a one-character change — removing a single extra backtick — and does not affect any code, configuration, or functionality.

## Verification

- Confirmed the four-backtick sequence exists on the `develop` branch of `python-lsp/python-lsp-server`
- Verified the fix produces valid Markdown (no remaining four-backtick sequences)
- No other content changes

## AI Usage Disclosure

An AI assistant was used to help locate the issue and draft this change. I have reviewed and understand every line of the diff, and I am the sole author of this contribution.
