### PR TITLE
Respect pydocstyle add-select and add-ignore settings

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -57,8 +57,8 @@ This server can be configured using the `workspace/didChangeConfiguration` metho
 | `pylsp.plugins.pycodestyle.indentSize` | `integer` | Set indentation spaces. | `null` |
 | `pylsp.plugins.pydocstyle.enabled` | `boolean` | Enable or disable the plugin. | `false` |
 | `pylsp.plugins.pydocstyle.convention` | `string` (one of: `'pep257'`, `'numpy'`, `'google'`, `None`) | Choose the basic list of checked errors by specifying an existing convention. | `null` |
-| `pylsp.plugins.pydocstyle.addIgnore` | `array` of unique `string` items | Ignore errors and warnings in addition to the specified convention. | `[]` |
-| `pylsp.plugins.pydocstyle.addSelect` | `array` of unique `string` items | Select errors and warnings in addition to the specified convention. | `[]` |
+| `pylsp.plugins.pydocstyle.addIgnore` | `array` of unique `string` items | Ignore errors and warnings in addition to the basic list of checked errors. | `[]` |
+| `pylsp.plugins.pydocstyle.addSelect` | `array` of unique `string` items | Select errors and warnings in addition to the basic list of checked errors. | `[]` |
 | `pylsp.plugins.pydocstyle.ignore` | `array` of unique `string` items | Ignore errors and warnings | `[]` |
 | `pylsp.plugins.pydocstyle.select` | `array` of unique `string` items | Select errors and warnings | `null` |
 | `pylsp.plugins.pydocstyle.match` | `string` | Check only files that exactly match the given regular expression; default is to match files that don't start with 'test_' but end with '.py'. | `"(?!test_).*\\.py"` |

--- a/pylsp/config/schema.json
+++ b/pylsp/config/schema.json
@@ -396,7 +396,7 @@
         "type": "string"
       },
       "uniqueItems": true,
-      "description": "Ignore errors and warnings in addition to the specified convention."
+      "description": "Ignore errors and warnings in addition to the basic list of checked errors."
     },
     "pylsp.plugins.pydocstyle.addSelect": {
       "type": "array",
@@ -405,7 +405,7 @@
         "type": "string"
       },
       "uniqueItems": true,
-      "description": "Select errors and warnings in addition to the specified convention."
+      "description": "Select errors and warnings in addition to the basic list of checked errors."
     },
     "pylsp.plugins.pydocstyle.ignore": {
       "type": "array",

--- a/pylsp/plugins/pydocstyle_lint.py
+++ b/pylsp/plugins/pydocstyle_lint.py
@@ -47,16 +47,15 @@ def pylsp_lint(config, workspace, document):
 
         if settings.get("convention"):
             args.append("--convention=" + settings["convention"])
-
-            if settings.get("addSelect"):
-                args.append("--add-select=" + ",".join(settings["addSelect"]))
-            if settings.get("addIgnore"):
-                args.append("--add-ignore=" + ",".join(settings["addIgnore"]))
-
         elif settings.get("select"):
             args.append("--select=" + ",".join(settings["select"]))
         elif settings.get("ignore"):
             args.append("--ignore=" + ",".join(settings["ignore"]))
+
+        if settings.get("addSelect"):
+            args.append("--add-select=" + ",".join(settings["addSelect"]))
+        if settings.get("addIgnore"):
+            args.append("--add-ignore=" + ",".join(settings["addIgnore"]))
 
         log.info("Using pydocstyle args: %s", args)
 

--- a/test/plugins/test_pydocstyle_lint.py
+++ b/test/plugins/test_pydocstyle_lint.py
@@ -38,6 +38,28 @@ def test_pydocstyle(config, workspace) -> None:
     }
 
 
+def test_pydocstyle_add_ignore_with_select(config, workspace) -> None:
+    config.update(
+        {"plugins": {"pydocstyle": {"select": ["D100"], "addIgnore": ["D100"]}}}
+    )
+    doc = Document(DOC_URI, workspace, DOC)
+
+    diags = pydocstyle_lint.pylsp_lint(config, workspace, doc)
+
+    assert not diags
+
+
+def test_pydocstyle_add_select_with_ignore(config, workspace) -> None:
+    config.update(
+        {"plugins": {"pydocstyle": {"ignore": ["D100"], "addSelect": ["D100"]}}}
+    )
+    doc = Document(DOC_URI, workspace, DOC)
+
+    diags = pydocstyle_lint.pylsp_lint(config, workspace, doc)
+
+    assert {diag["code"] for diag in diags} == {"D100", "D103"}
+
+
 def test_pydocstyle_test_document(config, workspace) -> None:
     # The default --match argument excludes test_* documents.
     doc = Document(TEST_DOC_URI, workspace, "")


### PR DESCRIPTION
Fixes #626

## Summary

- apply `addSelect` and `addIgnore` independently of the selected basic error list
- add regression coverage for combining `addIgnore` with `select` and `addSelect` with `ignore`
- clarify the generated configuration reference for both additive settings

## Tests

- `pytest -q test/plugins/test_pydocstyle_lint.py` (6 passed)
- `pytest -o addopts="" -q test/ -k "not test_missing_message"` (203 passed, 9 skipped, 1 deselected)
- `ruff check pylsp test`
- `ruff format --check pylsp test`
- JSON schema validation and generated configuration sync check

## Local baseline note

`test_missing_message` has an unrelated teardown error on the unchanged `develop` branch with local Python 3.14 (`config` is `None` during shutdown), so it was excluded from the second full-suite run after confirming the same behavior against the baseline.