### PR TITLE
fix: preserve list order when merging settings

### DIFF
--- a/pylsp/_utils.py
+++ b/pylsp/_utils.py
@@ -187,7 +187,7 @@ def merge_dicts(dict_a, dict_b):
                 if isinstance(a[key], dict) and isinstance(b[key], dict):
                     yield (key, dict(_merge_dicts_(a[key], b[key])))
                 elif isinstance(a[key], list) and isinstance(b[key], list):
-                    yield (key, list(set(a[key] + b[key])))
+                    yield (key, list(dict.fromkeys(a[key] + b[key])))
                 elif b[key] is not None:
                     yield (key, b[key])
                 else:

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -222,6 +222,17 @@ def test_merge_dicts() -> None:
     ) == {"a": False, "b": {"x": 123, "y": [], "z": 987}}
 
 
+def test_merge_dicts_preserves_list_order() -> None:
+    assert _utils.merge_dicts({"items": [3, 2]}, {"items": [1, 3]}) == {
+        "items": [3, 2, 1]
+    }
+
+    overrides = ["--python-executable", "/tmp/venv/bin/python", True]
+    assert _utils.merge_dicts({"overrides": []}, {"overrides": overrides}) == {
+        "overrides": overrides
+    }
+
+
 def test_clip_column() -> None:
     assert _utils.clip_column(0, [], 0) == 0
     assert _utils.clip_column(2, ["123"], 0) == 2


### PR DESCRIPTION
Fixes #677.

## Problem

`merge_dicts()` merges two list values with `list(set(a + b))`. The set removes duplicates but also discards first-occurrence order, so configuration lists can vary across hash seeds. This is observable for ordered argument lists such as `pylsp_mypy` overrides, where option and value positions matter.

The existing merge behavior, introduced in #38, concatenates both lists and removes duplicates. This change preserves that behavior rather than redefining duplicate handling.

## Change

- replace set-based deduplication with `dict.fromkeys(...)` so the first occurrence wins and list order is stable
- add regression coverage for cross-list duplicates and a mixed string/boolean override list matching the reported configuration shape

## Validation

- `pytest test/test_utils.py -q` - 10 passed
- `$env:PYTHONUTF8='1'; python -m pytest test/ -q --deselect=test/test_language_server.py::test_missing_message` - 190 passed, 21 skipped, 1 deselected
- `ruff check pylsp test`
- `ruff format --check pylsp test`
- `git diff --check`

`test_missing_message` is the single deselected test. It times out in this local Windows environment on both the unmodified `develop` commit and this branch; it does not exercise `_utils.merge_dicts`.
